### PR TITLE
Make minor style improvements.

### DIFF
--- a/js/ui/iconGridLayout.js
+++ b/js/ui/iconGridLayout.js
@@ -223,8 +223,10 @@ const IconGridLayout = new Lang.Class({
         }
 
         if (!this.iconIsFolder(info.get_id())) {
-            let eventRecorder = EosMetrics.EventRecorder.prototype.get_default();
-            eventRecorder.record_event(EosMetrics.EVENT_SHELL_APP_REMOVED, new GLib.Variant('s', info.get_id()));
+            let eventRecorder = EosMetrics.EventRecorder.get_default();
+            let appId = new GLib.Variant('s', info.get_id());
+            eventRecorder.record_event(EosMetrics.EVENT_SHELL_APP_REMOVED,
+                                       appId);
         }
 
         let filename = info.get_filename();

--- a/js/ui/shellDBus.js
+++ b/js/ui/shellDBus.js
@@ -468,8 +468,9 @@ const AppStoreService = new Lang.Class({
     },
 
     AddApplication: function(id) {
-        let eventRecorder = EosMetrics.EventRecorder.prototype.get_default();
-        eventRecorder.record_event(EosMetrics.EVENT_SHELL_APP_ADDED, new GLib.Variant('s', id));
+        let eventRecorder = EosMetrics.EventRecorder.get_default();
+        let appId = new GLib.Variant('s', id);
+        eventRecorder.record_event(EosMetrics.EVENT_SHELL_APP_ADDED, appId);
 
         if (!IconGridLayout.layout.iconIsFolder(id)) {
             IconGridLayout.layout.appendIcon(id, IconGridLayout.DESKTOP_GRID_ID);

--- a/js/ui/viewSelector.js
+++ b/js/ui/viewSelector.js
@@ -252,12 +252,10 @@ const ViewsDisplay = new Lang.Class({
     },
 
     _recordDesktopSearchMetric: function (query, searchProvider) {
-        let recorder = EosMetrics.EventRecorder.get_default();
-        recorder.record_event(EVENT_DESKTOP_SEARCH,
-            new GLib.Variant('(us)', [
-                searchProvider,
-                query
-            ]));
+        let eventRecorder = EosMetrics.EventRecorder.get_default();
+        let auxiliaryPayload =
+            new GLib.Variant('(us)', [searchProvider, query]);
+        eventRecorder.record_event(EVENT_DESKTOP_SEARCH, auxiliaryPayload);
     },
 
     _updateSpinner: function() {


### PR DESCRIPTION
Replace "EventRecorder.prototype.get_default()" with
"EventRecorder.get_default()" for brevity. Give the auxiliary payload
variables their own lines and names for clarity and to reduce the amount
of activity on any given line.

[endlessm/eos-sdk#2906]
