### PR TITLE
power: report "Fully charged" when battery is 100% charged

### DIFF
--- a/js/ui/status/power.js
+++ b/js/ui/status/power.js
@@ -97,8 +97,12 @@ const Indicator = new Lang.Class({
                 let time = Math.round(seconds / 60);
                 if (time == 0) {
                     // 0 is reported when UPower does not have enough data
-                    // to estimate battery life
-                    this._batteryItem.label.text = _("Estimating…");
+                    // to estimate battery life or when the battery is
+                    // fully charged
+                    if (state == UPDeviceState.FULLY_CHARGED)
+                        this._batteryItem.label.text = _("Fully Charged");
+                    else
+                        this._batteryItem.label.text = _("Estimating…");
                 } else {
                     let minutes = time % 60;
                     let hours = Math.floor(time / 60);

--- a/po/ar.po
+++ b/po/ar.po
@@ -1748,6 +1748,9 @@ msgstr "البطارية"
 msgid "Power Settings"
 msgstr "إعدادات الطاقة"
 
+msgid "Fully Charged"
+msgstr "مشحونة بالكامل"
+
 #. 0 is reported when UPower does not have enough data
 #. to estimate battery life
 #: ../js/ui/status/power.js:101

--- a/po/es.po
+++ b/po/es.po
@@ -1737,6 +1737,9 @@ msgstr "Batería"
 msgid "Power Settings"
 msgstr "Configuración de energía"
 
+msgid "Fully charged"
+msgstr "Cargada completamente"
+
 #. 0 is reported when UPower does not have enough data
 #. to estimate battery life
 #: ../js/ui/status/power.js:101

--- a/po/fr.po
+++ b/po/fr.po
@@ -1734,6 +1734,9 @@ msgstr "Batterie"
 msgid "Power Settings"
 msgstr "Paramètres de gestion de l'énergie"
 
+msgid "Fully Charged"
+msgstr "Charge complète"
+
 #. 0 is reported when UPower does not have enough data
 #. to estimate battery life
 #: ../js/ui/status/power.js:101

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -1743,6 +1743,9 @@ msgstr "Bateria"
 msgid "Power Settings"
 msgstr "Configurações de economia de energia"
 
+msgid "Fully Charged"
+msgstr "Completamente carregada"
+
 #. 0 is reported when UPower does not have enough data
 #. to estimate battery life
 #: ../js/ui/status/power.js:101


### PR DESCRIPTION
UPower reports time == 0 also when the battery is fully charged. Check
the battery state to report the correct message.

[endlessm/eos-shell#4643]
