### PR TITLE
Use eos-app desktop files for control cetner & yelp

### DIFF
--- a/js/ui/remoteSearch.js
+++ b/js/ui/remoteSearch.js
@@ -11,7 +11,7 @@ const IconGridLayout = imports.ui.iconGridLayout;
 const Search = imports.ui.search;
 
 const KEY_FILE_GROUP = 'Shell Search Provider';
-const CONTROL_CENTER_DESKTOP_ID = 'gnome-control-center.desktop';
+const CONTROL_CENTER_DESKTOP_ID = 'eos-app-gnome-control-center.desktop';
 
 const SearchProviderIface = '<node> \
 <interface name="org.gnome.Shell.SearchProvider"> \

--- a/js/ui/userMenu.js
+++ b/js/ui/userMenu.js
@@ -40,7 +40,8 @@ const SETTINGS_TEXT = _("Settings");
 const FEEDBACK_TEXT = _("Give Us Feedback");
 
 const FEEDBACK_LAUNCHER = "eos-app-feedback.desktop";
-const YELP_LAUNCHER = "yelp.desktop";
+const YELP_LAUNCHER = "eos-app-yelp.desktop";
+const CONTROL_CENTER_LAUNCHER = "eos-app-gnome-control-center.desktop";
 
 const DIALOG_ICON_SIZE = 64;
 
@@ -536,7 +537,7 @@ const UserMenuButton = new Lang.Class({
 
     _onPreferencesActivate: function() {
         Main.overview.hide();
-        let app = Shell.AppSystem.get_default().lookup_app('gnome-control-center.desktop');
+        let app = Shell.AppSystem.get_default().lookup_app(CONTROL_CENTER_LAUNCHER);
         app.activate();
     },
 


### PR DESCRIPTION
The system defaults are now overridden by ones provided
via eos-shell-content, and we need to call out the eos-app
versions to avoid quirkiness with the icons on the taskbar.

[endlessm/eos-shell#4571]
[endlessm/eos-shell#4572]
