### PR TITLE
theme: search icon labels fit always fit in hover box

### DIFF
--- a/data/theme/gnome-shell.css
+++ b/data/theme/gnome-shell.css
@@ -1207,7 +1207,7 @@ StScrollBar StButton#vhandle:active {
 .app-well-app > .overview-icon,
 .overview-icon .show-apps {
     border-radius: 4px;
-    padding: 3px;
+    padding: 13px;
     border: 1px rgba(0,0,0,0);
     transition-duration: 100ms;
     text-align: center;


### PR DESCRIPTION
Our icon grid labels have a manual width set in css, for the search
results icons, we need lower the label size to fit within the hover
box.
[endlessm/eos-shell#3708]
