### PR TITLE
search: When animating, update results before activating one

### DIFF
--- a/js/ui/search.js
+++ b/js/ui/search.js
@@ -793,6 +793,10 @@ const SearchResults = new Lang.Class({
     },
 
     activateDefault: function() {
+        // If we are about to activate a result, we are done animating and need
+        // to update the display immediately.
+        this.isAnimating = false;
+
         // If we have a search queued up, force the search now.
         if (this._searchTimeoutId > 0)
             this._doSearch();


### PR DESCRIPTION
We freeze the results while animating the search upwards to avoid
bombarding the user with changing elements and to keep frame rates
smooth.

If our results are activated while the animation is happening, we
need to unfreeze the results first. Otherwise we will launch the
default result for the query entered when the animation started,
instead of the current query.
[endlessm/eos-shell#4767]
