### PR TITLE
theme: Restore show apps button to proper size

### DIFF
--- a/data/theme/gnome-shell.css
+++ b/data/theme/gnome-shell.css
@@ -1207,10 +1207,18 @@ StScrollBar StButton#vhandle:active {
 .app-well-app > .overview-icon,
 .overview-icon .show-apps {
     border-radius: 4px;
-    padding: 13px;
     border: 1px rgba(0,0,0,0);
     transition-duration: 100ms;
     text-align: center;
+}
+
+.overview-icon.dnd,
+.app-well-app > .overview-icon {
+    padding: 13px;
+}
+
+.overview-icon .show-apps {
+    padding: 3px;
 }
 
 .dash-item-container .overview-icon {


### PR DESCRIPTION
A previous theme commit to fix the selected box on our icon grid
accidentally broke show apps size.

The icon grid icons and dash show apps icon were padded in the same
set of selectors, separated them.
[endlessm/eos-shell#3708]
