### PR TITLE
search: update search status message when its shown

### DIFF
--- a/js/ui/search.js
+++ b/js/ui/search.js
@@ -766,7 +766,7 @@ const SearchResults = new Lang.Class({
         this._topContent.visible = haveResults;
         this._statusBin.visible = showStatus;
 
-        if (!showStatus) {
+        if (showStatus) {
             if (this.searchInProgress) {
                 this._statusText.set_text(_("Searching…"));
             } else {


### PR DESCRIPTION
A brainfart improperly using a boolean variable led to us always
showing the "Searching..." status text and never the no results
text.
[endlessm/eos-shell#4797]
