### PR TITLE
viewSelector: no timeout for search results when animating

### DIFF
--- a/js/ui/viewSelector.js
+++ b/js/ui/viewSelector.js
@@ -267,7 +267,12 @@ const ViewsDisplay = new Lang.Class({
             return;
 
         // We give a very short time for search results to populate before
-        // triggering the animation
+        // triggering the animation, unless an animation is already in progress
+        if (this._searchResults.isAnimating) {
+            this.actor.showPage(ViewsDisplayPage.SEARCH, true);
+            return;
+        }
+
         this._enterSearchTimeoutId = Mainloop.timeout_add(SEARCH_ACTIVATION_TIMEOUT, Lang.bind(this, function () {
             this._enterSearchTimeoutId = 0;
             this.actor.showPage(ViewsDisplayPage.SEARCH, true);


### PR DESCRIPTION
When the search results is first activated, we set a small 50ms
timeout to populate some results before triggering its animation
to visible.

However, if we are already in an animation state somewhere (say
animating the search results invisible) we should not bother
with that timeout.
[endlessm/eos-shell#4766]
