### PR TITLE
Shutdown button is now red and enabled use of syle classes for ModalDialog

### DIFF
--- a/data/theme/gnome-shell.css
+++ b/data/theme/gnome-shell.css
@@ -2212,6 +2212,26 @@ StScrollBar StButton#vhandle:active {
     padding: 3px 31px 4px;
 }
 
+.modal-dialog-button.shutdown {
+    background-gradient-start: rgba(255, 0, 0, 0.4);
+    background-gradient-end: rgba(255, 0, 0, 0.1);
+}
+
+.modal-dialog-button.shutdown:hover {
+    background-gradient-start: rgba(255, 0, 0, 0.5);
+    background-gradient-end: rgba(255, 0, 0, 0.3);
+}
+
+.modal-dialog-button.shutdown:active,
+.modal-dialog-button.shutdown:pressed {
+    background-gradient-start: rgba(255, 0, 0, 0.0);
+    background-gradient-end: rgba(255, 0, 0, 0.3);
+}
+
+.modal-dialog-button.shutdown:insensitive {
+    background-color: rgba(102, 0, 0, 0.25);
+}
+
 /* Run Dialog */
 
 .run-dialog-label {

--- a/js/ui/endSessionDialog.js
+++ b/js/ui/endSessionDialog.js
@@ -124,7 +124,8 @@ const shutdownDialogContent = {
                      { signal: 'ConfirmedReboot',
                        label:  C_("button", "Restart") },
                      { signal: 'ConfirmedShutdown',
-                       label:  C_("button", "Power Off") }],
+                       label:  C_("button", "Power Off"),
+                       style_class: 'shutdown' }],
     iconName: 'system-shutdown-symbolic',
     iconStyleClass: 'end-session-dialog-shutdown-icon'
 };
@@ -424,6 +425,7 @@ const EndSessionDialog = new Lang.Class({
         for (let i = 0; i < dialogContent.confirmButtons.length; i++) {
             let signal = dialogContent.confirmButtons[i].signal;
             let label = dialogContent.confirmButtons[i].label;
+            let style_class = dialogContent.confirmButtons[i].style_class;
             buttons.push({ action: Lang.bind(this, function() {
                                        this.close(true);
                                        let signalId = this.connect('closed',
@@ -432,7 +434,8 @@ const EndSessionDialog = new Lang.Class({
                                                                        this._confirm(signal);
                                                                    }));
                                    }),
-                           label: label });
+                           label: label,
+                           style_class: style_class });
         }
 
         this.setButtons(buttons);

--- a/js/ui/modalDialog.js
+++ b/js/ui/modalDialog.js
@@ -152,6 +152,7 @@ const ModalDialog = new Lang.Class({
         let action = buttonInfo['action'];
         let key = buttonInfo['key'];
         let isDefault = buttonInfo['default'];
+        let styleClass = buttonInfo['style_class'];
 
         let keys;
 
@@ -173,6 +174,9 @@ const ModalDialog = new Lang.Class({
 
         if (isDefault)
             button.add_style_pseudo_class('default');
+
+        if (styleClass)
+            button.add_style_class_name(styleClass);
 
         if (!this._initialKeyFocusDestroyId)
             this._initialKeyFocus = button;


### PR DESCRIPTION
This change turns the endSessionDialog's shutdown button red and in the
process of getting this to work, we can now add style classes to modal
dialog buttons.

[endlessm/eos-shell#2443]
