### PR TITLE
updateManager: fizzle out notification when state did not change

### DIFF
--- a/js/ui/components/updaterManager.js
+++ b/js/ui/components/updaterManager.js
@@ -140,6 +140,10 @@ const UpdaterManager = new Lang.Class({
     _onStateChanged: function() {
         let state = this._proxy.State;
 
+        if (state == this._currentState) {
+            return;
+        }
+
         if (state == UpdaterState.UPDATE_AVAILABLE) {
             this._notifyUpdateAvailable();
         } else if (state == UpdaterState.UPDATE_READY) {


### PR DESCRIPTION
Do not emit a notification if the state did not actually change.

[endlessm/eos-shell#4704]
