### PR TITLE
Shell: Reduced the padding size for the app grid

### DIFF
--- a/data/theme/gnome-shell.css
+++ b/data/theme/gnome-shell.css
@@ -1196,7 +1196,7 @@ StScrollBar StButton#vhandle:active {
 .search-display > StBoxLayout,
 .all-apps > StBoxLayout {
     /* horizontal padding to make sure scrollbars or dash don't overlap content */
-    padding: 0px 84px;
+    padding: 0px 70px;
 }
 
 .app-folder-icon {


### PR DESCRIPTION
This prevents the shifting of the grid due to some clones returning
different column counts, thus changing the allocations for the grid
arbitrarly. While this might fix some special cases, it's still a hack
that really needs to be fixed by figuring out why the clones are getting
wrong "forWidth" values and thus calculating wrong column sizes.

[endlessm/eos-shell#4789]
