### PR TITLE
search: clicking search panel does not hide search

### DIFF
--- a/js/ui/search.js
+++ b/js/ui/search.js
@@ -440,8 +440,11 @@ const SearchResults = new Lang.Class({
 
     _init: function() {
         this.actor = new SearchResultsBin({ name: 'searchResults',
+                                            reactive: true,
                                             y_align: Clutter.ActorAlign.FILL,
                                             layout_manager: new Clutter.BinLayout() });
+        this.actor.connect('button-press-event', function () { return true; });
+        this.actor.connect('button-release-event', function () { return true; });
 
         let box = new St.BoxLayout({ name: 'searchResultsBox',
                                      vertical: true,


### PR DESCRIPTION
Clicking off the panel, or clicking the X button will hide search,
but any click on the panel background will not cause a hide.
[endlessm/eos-shell#4891]
