### PR TITLE
endSessionDialog: add style class for shutdown in any case

### DIFF
--- a/js/ui/endSessionDialog.js
+++ b/js/ui/endSessionDialog.js
@@ -118,7 +118,8 @@ const shutdownDialogContent = {
                     [{ signal: 'ConfirmedReboot',
                        label:  C_("button", "Restart") },
                      { signal: 'ConfirmedShutdown',
-                       label:  C_("button", "Power Off") }] :
+                       label:  C_("button", "Power Off"),
+                       style_class: 'shutdown' }] :
                     [{ signal: 'ConfirmedLogout',
                        label:  C_("button", "Log Out") },
                      { signal: 'ConfirmedReboot',


### PR DESCRIPTION
Even when the separate power off gsettings key is set.

[endlessm/eos-shell#2443]
