### PR TITLE
viewSelector: move icon grid placement down slightly

### DIFF
--- a/data/theme/gnome-shell.css
+++ b/data/theme/gnome-shell.css
@@ -1193,6 +1193,10 @@ StScrollBar StButton#vhandle:active {
     text-shadow: none;
 }
 
+.all-apps {
+    -natural-padding-top: 25px;
+}
+
 .search-display > StBoxLayout,
 .all-apps > StBoxLayout {
     /* horizontal padding to make sure scrollbars or dash don't overlap content */


### PR DESCRIPTION
We want the icons inside the icon grid to appear perfectly centered
in the desktop area, so we add some padding to the top of the icon
grid when possible, to offset the presence of the icon labels at
the bottom of the grid.

With our current sizing model, the ViewsDisplayLayout seemed the
only place to handle this correctly.
[endlessm/eos-shell#4874]
