### PR TITLE
Make the shell use org.freedesktop.login1.Manager.CanSuspend again

### DIFF
--- a/js/misc/loginManager.js
+++ b/js/misc/loginManager.js
@@ -192,7 +192,7 @@ const LoginManagerSystemd = new Lang.Class({
             if (error)
                 asyncCallback(false);
             else
-                asyncCallback(result[0] != 'no');
+                asyncCallback(result[0] != 'no' && result[0] != 'na');
         });
     },
 

--- a/js/misc/loginManager.js
+++ b/js/misc/loginManager.js
@@ -174,7 +174,7 @@ const LoginManagerSystemd = new Lang.Class({
             if (error)
                 asyncCallback(false);
             else
-                asyncCallback(result[0] != 'no');
+                asyncCallback(result[0] != 'no' && result[0] != 'na');
         });
     },
 
@@ -183,7 +183,7 @@ const LoginManagerSystemd = new Lang.Class({
             if (error)
                 asyncCallback(false);
             else
-                asyncCallback(result[0] != 'no');
+                asyncCallback(result[0] != 'no' && result[0] != 'na');
         });
     },
 

--- a/js/misc/loginManager.js
+++ b/js/misc/loginManager.js
@@ -189,13 +189,10 @@ const LoginManagerSystemd = new Lang.Class({
 
     canSuspend: function(asyncCallback) {
         this._proxy.CanSuspendRemote(function(result, error) {
-            // FIXME: we disable all suspend actions from the UI for now
-            // if (error)
-            //     asyncCallback(false);
-            // else
-            //     asyncCallback(result[0] != 'no');
-
-            asyncCallback(false);
+            if (error)
+                asyncCallback(false);
+            else
+                asyncCallback(result[0] != 'no');
         });
     },
 


### PR DESCRIPTION
Make the shell rely again in whatever reply gets from org.freedesktop.login1.Manager.CanSuspend, to decide whether to enable the Alt-based switcher for the power button, which would now show a suspend button if possible, while Alt is pressed.

This PR also fixes the callbacks for org.freedesktop.login1's CanSuspend, CanPowerOff and CanReboot, since they were not considering 'na' as a possible negative answer, when it should be. Otherwise, the blacklisting/whitelisting mechanism implemented in https://github.com/endlessm/systemd/commit/86d4feae5befca7f579f414da19574b17add209e won't work, since 'na' will be the reply that we would be getting in those cases. See https://bugzilla.gnome.org/show_bug.cgi?id=748338 for more details in the bug reported upstream, where only CanSuspend was a concern.

[endlessm/eos-shell#4655]