### PR TITLE
tests: Use local GSettings schema dir

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -70,6 +70,7 @@ TESTS_ENVIRONMENT = \
 	export GJS_PATH='$(top_srcdir):$(top_srcdir)/js:$(top_srcdir)/tests/unit'; \
 	export GI_TYPELIB_PATH='$(top_builddir)/src:$(top_builddir)/src/gvc:$(MUTTER_TYPELIB_DIR):${GI_TYPELIB_PATH}'; \
 	export LD_LIBRARY_PATH='$(top_builddir)/src/:${GI_TYPELIB_PATH}'; \
+	export GSETTINGS_SCHEMA_DIR='$(top_builddir)/data'; \
 	$(NULL)
 
 EXTRA_DIST += \


### PR DESCRIPTION
Apparently a real GSettings object is created at some point during the
tests. If the GSettings schema is not installed, for example on a CI
machine, then the tests will fail. This changes the environment to use
the compiled GSettings schema in the local source tree.

[endlessm/eos-sdk#3054]