### PR TITLE
Fix hot corner

### DIFF
--- a/js/ui/layout.js
+++ b/js/ui/layout.js
@@ -1503,7 +1503,11 @@ const HotCorner = new Lang.Class({
     },
 
     _setupFallbackCornerIfNeeded: function(layoutManager) {
-        if (!global.display.supports_extended_barriers()) {
+        // FIXME: The pressure barrier is not working properly.
+        //        It is preventing use of the hot corner,
+        //        so temporarily disable it.
+        // if (!global.display.supports_extended_barriers()) {
+        if (true) {
             this.actor = new Clutter.Actor({ name: 'hot-corner-environs',
                                              x: this._x, y: this._y,
                                              width: 3,


### PR DESCRIPTION
Work around broken pressure barrier.

With the recent upgrade to X, the display server now supports
extended barriers, but the functionality is currently broken
and preventing use of the hot corner.

[endlessm/eos-shell#5006]