### PR TITLE
Disable message tray pressure barrier by default

### DIFF
--- a/data/org.gnome.shell.gschema.xml.in.in
+++ b/data/org.gnome.shell.gschema.xml.in.in
@@ -183,6 +183,17 @@ value here is from the GsmPresenceStatus enumeration.</_summary>
         This key specifies the exact order of the icons shown in the applications launcher view.
       </_description>
     </key>
+    <key name="enable-message-tray-barrier" type="b">
+      <default>false</default>
+      <_summary>
+        Enables the pressure barrier for the message tray
+      </_summary>
+      <_description>
+        By default, the message tray is only shown on key press.
+        Set true to show the message tray when exerting downward pressure
+        with the cursor on the bottom of the taskbar.
+      </_description>
+    </key>
     <child name="calendar" schema="org.gnome.shell.calendar"/>
     <child name="keybindings" schema="org.gnome.shell.keybindings"/>
     <child name="keyboard" schema="org.gnome.shell.keyboard"/>

--- a/js/ui/layout.js
+++ b/js/ui/layout.js
@@ -24,6 +24,9 @@ const KEYBOARD_ANIMATION_TIME = 0.15;
 const BACKGROUND_FADE_ANIMATION_TIME = 1.0;
 const DEFAULT_BACKGROUND_COLOR = Clutter.Color.from_pixel(0x2e3436ff);
 
+// Gsettings key to enable the message tray pressure barrier.
+const ENABLE_MESSAGE_TRAY_BARRIER_KEY = 'enable-message-tray-barrier'
+
 // The message tray takes this much pressure
 // in the pressure barrier at once to release it.
 const MESSAGE_TRAY_PRESSURE_THRESHOLD = 250; // pixels
@@ -734,7 +737,9 @@ const LayoutManager = new Lang.Class({
             if (Main.layoutManager.bottomMonitor.inFullscreen)
                 return;
 
-            Main.messageTray.openTray();
+            if (global.settings.get_boolean(ENABLE_MESSAGE_TRAY_BARRIER_KEY)) {
+                Main.messageTray.openTray();
+            }
         });
     },
 


### PR DESCRIPTION
This feature was implicitly enabled due to the recent Xorg update.
This is not an element of the Endless OS dekstop user experience,
so disable it by default, but make it controllable via a gsetting
so that advanced users can enable the feature at runtime.

[endlessm/eos-shell#5042]