### PR TITLE
Add ./jasmine script to run tests

### DIFF
--- a/jasmine
+++ b/jasmine
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+MUTTER_TYPELIB_DIR=`pkg-config --variable=typelibdir libmutter`
+export GI_TYPELIB_PATH="src:src/gvc:$MUTTER_TYPELIB_DIR:$GI_TYPELIB_PATH"
+export LD_LIBRARY_PATH="src:$GI_TYPELIB_PATH"
+export GSETTINGS_SCHEMA_DIR=data
+
+src/run-js-test `which jasmine`

--- a/jasmine.json
+++ b/jasmine.json
@@ -1,0 +1,5 @@
+{
+  "include_paths": [".", "js", "tests/unit"],
+  "options": "--verbose",
+  "spec_files": ["tests/js/ui", "tests/unit"]
+}

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -54,7 +54,8 @@ JS_LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) $(top_srcdir)/config/tap-driver
 JS_LOG_DRIVER_FLAGS = --comments
 # run-js-test is a binary that is linked to libeos-shell and runs a GJS script;
 # libst isn't built as a shared library, so it's impossible to import the St-1.0
-# typelib directly from GJS.
+# typelib directly from GJS. Unfortunately, this means we can't run tests by
+# just typing "jasmine" - we need the ./jasmine script.
 JS_LOG_COMPILER = $(top_builddir)/src/run-js-test
 AM_JS_LOG_FLAGS = \
 	$(JASMINE) \


### PR DESCRIPTION
For ease of use, this adds a ./jasmine script that runs all the tests
against the uninstalled code, the same as "make check" does but with a
much more readable output.

Because of technical limitations with setting the mutter typelib dir and
requiring the "run-js-tests" loader, we can't achieve this by simply
executing the "jasmine" command like we do in other packages.

[endlessm/eos-sdk#3171]