### PR TITLE
Generate XML reports when running on Jenkins

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -184,6 +184,16 @@ AM_CONDITIONAL(USE_JHBUILD_WRAPPER_SCRIPT, test "x$enable_jhbuild_wrapper_script
 BROWSER_PLUGIN_DIR="${BROWSER_PLUGIN_DIR:-"\${libdir}/mozilla/plugins"}"
 AC_ARG_VAR([BROWSER_PLUGIN_DIR],[Where to install the plugin to])
 
+# JASMINE_JUNIT_REPORTS_DIR: Where to put test reports
+AC_MSG_CHECKING([where to put test reports])
+AC_ARG_VAR([JASMINE_JUNIT_REPORTS_DIR], [Where to put test reports])
+AS_IF([test -n "$JASMINE_JUNIT_REPORTS_DIR"],
+  [JASMINE_REPORT_ARGUMENT="--junit $JASMINE_JUNIT_REPORTS_DIR/\$\${log/%.log/.js.xml}"
+  AC_MSG_RESULT([in $JASMINE_JUNIT_REPORTS_DIR])],
+  [JASMINE_REPORT_ARGUMENT=
+  AC_MSG_RESULT([nowhere])])
+AC_SUBST([JASMINE_REPORT_ARGUMENT])
+
 # Enable coverage reporting
 EOS_COVERAGE_REPORT([c js])
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -60,6 +60,7 @@ JS_LOG_COMPILER = $(top_builddir)/src/run-js-test
 AM_JS_LOG_FLAGS = \
 	$(JASMINE) \
 	--tap \
+	@JASMINE_REPORT_ARGUMENT@ \
 	@EOS_JS_COVERAGE_LOG_FLAGS@
 
 LOG_COMPILER = gtester


### PR DESCRIPTION
If we detect a Jenkins environment using the environment variable
JASMINE_JUNIT_REPORTS_DIR that we set in the job's configuration, then
generate XML test reports for each Jasmine unit test.

[endlessm/eos-sdk#3172]