### PR TITLE
shellEntry: grab key focus before pasting

### DIFF
--- a/js/ui/shellEntry.js
+++ b/js/ui/shellEntry.js
@@ -142,6 +142,7 @@ const EntryEditMenu = new Lang.Class({
             function(clipboard, text) {
                 if (!text)
                     return;
+                this._entry.grab_key_focus();
                 this._entry.clutter_text.delete_selection();
                 let pos = this._entry.clutter_text.get_cursor_position();
                 this._entry.clutter_text.insert_text(text, pos);


### PR DESCRIPTION
This will make sure to remove any hint from the entry before the text
gets there.

[endlessm/eos-shell#5104]