### PR TITLE
Access static method on class, not instance

### DIFF
--- a/js/ui/appActivation.js
+++ b/js/ui/appActivation.js
@@ -511,7 +511,7 @@ const DesktopAppClient = new Lang.Class({
 
         this._lastDesktopApp = null;
 
-        if (tracker.is_window_interesting(metaWindow) && metaWindow.resizeable) {
+        if (Shell.WindowTracker.is_window_interesting(metaWindow) && metaWindow.resizeable) {
             // Position the window so it's at where we want it to be if the user
             // unmaximizes the window.
             let workArea = Main.layoutManager.getWorkAreaForMonitor(metaWindow.get_monitor());

--- a/js/ui/appIconBar.js
+++ b/js/ui/appIconBar.js
@@ -162,7 +162,6 @@ const AppIconMenu = new Lang.Class({
     _redisplay: function() {
         this._submenuItem.menu.removeAll();
 
-        let tracker = Shell.WindowTracker.get_default();
         let activeWorkspace = global.screen.get_active_workspace();
 
         let windows = this._app.get_windows();
@@ -170,7 +169,7 @@ const AppIconMenu = new Lang.Class({
         let otherWindows = [];
 
         windows.forEach(function(w) {
-            if (!tracker.is_window_interesting(w)) {
+            if (!Shell.WindowTracker.is_window_interesting(w)) {
                 return;
             }
 
@@ -350,9 +349,8 @@ const AppIconButton = new Lang.Class({
             this.emit('app-icon-pressed');
 
             let windows = this._app.get_windows();
-            let tracker = Shell.WindowTracker.get_default();
             windows = windows.filter(function(metaWindow) {
-                return tracker.is_window_interesting(metaWindow);
+                return Shell.WindowTracker.is_window_interesting(metaWindow);
             });
 
             if (windows.length > 1) {
@@ -394,9 +392,8 @@ const AppIconButton = new Lang.Class({
 
         // The multiple windows case is handled in button-press-event
         let windows = this._app.get_windows();
-        let tracker = Shell.WindowTracker.get_default();
         windows = windows.filter(function(metaWindow) {
-            return tracker.is_window_interesting(metaWindow);
+            return Shell.WindowTracker.is_window_interesting(metaWindow);
         });
 
         if (windows.length == 0) {
@@ -750,10 +747,8 @@ const ScrolledIconList = new Lang.Class({
             break;
         case Shell.AppState.RUNNING:
             let windows = app.get_windows();
-            let tracker = Shell.WindowTracker.get_default();
-
             retval = windows.some(function(metaWindow) {
-                return tracker.is_window_interesting(metaWindow);
+                return Shell.WindowTracker.is_window_interesting(metaWindow);
             });
             break;
         case Shell.AppState.STOPPED:

--- a/js/ui/workspace.js
+++ b/js/ui/workspace.js
@@ -1510,9 +1510,8 @@ const Workspace = new Lang.Class({
 
     // Tests if @win should be shown in the Overview
     _isOverviewWindow : function (win) {
-        let tracker = Shell.WindowTracker.get_default();
         let metaWindow = win.get_meta_window();
-        return tracker.is_window_interesting(metaWindow) &&
+        return Shell.WindowTracker.is_window_interesting(metaWindow) &&
             !SideComponent.isSideComponentWindow(metaWindow);
     },
 

--- a/js/ui/workspaceMonitor.js
+++ b/js/ui/workspaceMonitor.js
@@ -146,8 +146,7 @@ const WorkspaceMonitor = new Lang.Class({
     //                 ways a window can be taken off the screen: minimizing and
     //                 closing
     _realWindowAdded: function(metaWindow) {
-        let tracker = Shell.WindowTracker.get_default();
-        if (!tracker.is_window_interesting(metaWindow)) {
+        if (!Shell.WindowTracker.is_window_interesting(metaWindow)) {
             return false;
         }
 

--- a/js/ui/workspaceThumbnail.js
+++ b/js/ui/workspaceThumbnail.js
@@ -426,8 +426,7 @@ const WorkspaceThumbnail = new Lang.Class({
 
     // Tests if @win should be shown in the Overview
     _isOverviewWindow : function (win) {
-        let tracker = Shell.WindowTracker.get_default();
-        return tracker.is_window_interesting(win.get_meta_window()) &&
+        return Shell.WindowTracker.is_window_interesting(win.get_meta_window()) &&
                win.get_meta_window().showing_on_its_workspace();
     },
 


### PR DESCRIPTION
The old GJS allowed you to access static methods on an instance of the
class that defined them. Not so with the new GJS. So instead of
any_widget.get_default_direction(), for example, we now must do
Gtk.Widget.get_default_direction(). In this case the offending method
was Shell.WindowTracker.is_window_interesting().

[endlessm/eos-sdk#3265]