### PR TITLE
updaterManager: Adjust to new dbus interface

### DIFF
--- a/js/ui/components/updaterManager.js
+++ b/js/ui/components/updaterManager.js
@@ -9,7 +9,7 @@ const Main = imports.ui.main;
 const MessageTray = imports.ui.messageTray;
 
 const UpdaterIface = '<node> \
-<interface name="org.gnome.OSTree"> \
+<interface name="com.endlessm.Updater"> \
   <method name="Poll"/> \
   <method name="Fetch"/> \
   <method name="Apply"/> \
@@ -76,8 +76,8 @@ const UpdaterManager = new Lang.Class({
     Name: 'UpdaterManager',
 
     _init: function() {
-        this._proxy = new UpdaterProxy(Gio.DBus.system, 'org.gnome.OSTree',
-                                       '/org/gnome/OSTree', Lang.bind(this, this._onProxyConstructed));
+        this._proxy = new UpdaterProxy(Gio.DBus.system, 'com.endlessm.Updater',
+                                       '/com/endlessm/Updater', Lang.bind(this, this._onProxyConstructed));
 
         this._session = new GnomeSession.SessionManager();
 


### PR DESCRIPTION
It was determined that the ostree daemon was not upstreamable, so the
interface has moved over to an Endless specific com.endlessm.Updater.
Adjust accordingly.

[endlessm/eos-shell#5087]