### PR TITLE
Change source package name back to eos-shell

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+eos-shell (3.8.0) master; urgency=medium
+
+  * Change source package name back to eos-shell. The installed paths are
+    derived from the source package name and break the binary packages.
+  [endlessm/eos-shell#5208]
+
+ -- Dan Nicholson <nicholson@endlessm.com>  Thu, 18 Jun 2015 16:24:15 -0700
+
 eos-desktop (3.8.0) unstable; urgency=low
 
   * Change package name

--- a/debian/control
+++ b/debian/control
@@ -1,4 +1,4 @@
-Source: eos-desktop
+Source: eos-shell
 Section: gnome
 Priority: optional
 Maintainer: Endless Mobile <maintainers@endlessm.com>


### PR DESCRIPTION
The debian packaging derives the install directories from the source
package name. When this changed to eos-desktop, some files moved to
places the autotools didn't install them to since the module name is
still eos-shell. This caused some required files to be lost from the
binary packages.

[endlessm/eos-shell#5208]