### PR TITLE
appDisplay: consolidate code for app icons activation

### DIFF
--- a/js/ui/appDisplay.js
+++ b/js/ui/appDisplay.js
@@ -72,6 +72,23 @@ function _sanitizeAppId(appId) {
     return appId;
 }
 
+function _activateApp(app, event) {
+    let modifiers = event ? event.get_state() : 0;
+
+    if (app.state == Shell.AppState.RUNNING) {
+        if (modifiers & Clutter.ModifierType.CONTROL_MASK) {
+            app.open_new_window(-1);
+        } else {
+            app.activate();
+        }
+    } else {
+        let activationContext = new AppActivation.AppActivationContext(app);
+        activationContext.activate();
+    }
+
+    Main.overview.hide();
+}
+
 const AppSearchProvider = new Lang.Class({
     Name: 'AppSearchProvider',
 
@@ -156,17 +173,7 @@ const AppSearchProvider = new Lang.Class({
 
     activateResult: function(app) {
         let event = Clutter.get_current_event();
-        let modifiers = event ? event.get_state() : 0;
-        let openNewWindow = modifiers & Clutter.ModifierType.CONTROL_MASK;
-
-        if (openNewWindow) {
-            app.open_new_window(-1);
-        } else {
-            let activationContext = new AppActivation.AppActivationContext(app);
-            activationContext.activate();
-        }
-
-        Main.overview.hide();
+        _activateApp(app, event);
     },
 
     dragActivateResult: function(id, params) {
@@ -1852,20 +1859,7 @@ const AppIcon = new Lang.Class({
 
     _onActivate: function (event) {
         this.emit('launching');
-
-        if (this.app.state == Shell.AppState.RUNNING) {
-            let modifiers = event.get_state();
-            if (modifiers & Clutter.ModifierType.CONTROL_MASK) {
-                this.app.open_new_window(-1);
-            } else {
-                this.app.activate();
-            }
-        } else {
-            let activationContext = new AppActivation.AppActivationContext(this.app);
-            activationContext.activate();
-        }
-
-        Main.overview.hide();
+        _activateApp(this.app, event);
     },
 
     shellWorkspaceLaunch : function(params) {


### PR DESCRIPTION
Differently from the desktop icon, the search icon code would not check
whether the application is already running before activating the splash
screen.
Consolidate this code in a separate function and call it from both
places.

This fixes a bug where the splash screen would appear for running
applications when launched from the search results.

[endlessm/eos-shell#5209]