### PR TITLE
ShellAppSystem: fix a crash when removing custom desktop files

### DIFF
--- a/src/shell-app-system.c
+++ b/src/shell-app-system.c
@@ -112,12 +112,23 @@ static gboolean
 app_is_stale (ShellApp *app)
 {
   GDesktopAppInfo *info;
+  const char *id;
   gboolean is_stale;
 
   if (shell_app_is_window_backed (app))
     return FALSE;
 
-  info = g_desktop_app_info_new (shell_app_get_id (app));
+  /* If g_app_info_delete() was called, such as when a custom desktop
+   * icon is removed, the desktop ID of the underlying GDesktopAppInfo
+   * will be set to NULL.
+   * So we explicitly check for that case and mark the app as stale.
+   * See https://git.gnome.org/browse/glib/tree/gio/gdesktopappinfo.c?h=glib-2-44&id=2.44.0#n3682
+   */
+  id = shell_app_get_id (app);
+  if (id == NULL)
+    return TRUE;
+
+  info = g_desktop_app_info_new (id);
   is_stale = (info == NULL);
 
   if (info)


### PR DESCRIPTION
When g_app_info_delete() is called, such as when removing a custom
launcher from the desktop, GIO will set the desktop ID field of the
GDesktopAppInfo to NULL automatically.
That breaks an assumption in ShellAppSystem that g_app_info_get_id()
does not change over the lifecycle of a GAppInfo. When iterating over
the app infos in response to a GIO change, we'll segfault when we hit
the deleted application.

This commit fixes the issue explicitly checking for g_app_info_get_id()
returning NULL after a change from the GAppInfoMonitor.

[endlessm/eos-shell#5379]