### PR TITLE
Unlock: do not map Esc key to Cancel

### DIFF
--- a/js/ui/unlockDialog.js
+++ b/js/ui/unlockDialog.js
@@ -95,8 +95,7 @@ const UnlockDialog = new Lang.Class({
         this.allowCancel = true;
         this.buttonLayout.visible = true;
         this.addButton({ label: _("Cancel"),
-                         action: Lang.bind(this, this._escape),
-                         key: Clutter.KEY_Escape },
+                         action: Lang.bind(this, this._escape) },
                        { expand: true,
                          x_fill: false,
                          y_fill: false,


### PR DESCRIPTION
Since the keystroke that wakes the screensaver is applied to the
unlock dialog, if the user tries to use the Esc key to exit the
screensaver (which is one of the most intuitive keys to do so),
the dialog is immediately canceled by this single Esc keystroke.

In the future, we may want to block the wake-up keystroke from
being applied to the password, in which case we could revert
this commit and re-enable the Esc key to cancel the dialog.

[endlessm/eos-shell#5213]