### PR TITLE
appActivation: Ignore splash screens on the _windowCreated callback

### DIFF
--- a/js/ui/appActivation.js
+++ b/js/ui/appActivation.js
@@ -270,6 +270,10 @@ const DesktopAppClient = new Lang.Class({
     },
 
     _windowCreated: function(metaDisplay, metaWindow) {
+        // Ignore splash screens, which will already be maximized.
+        if (metaWindow.get_role() == 'eos-speedwagon')
+            return;
+
         // Don't maximize if key to disable default maximize is set
         if (global.settings.get_boolean(WindowManager.NO_DEFAULT_MAXIMIZE_KEY)) {
             return;


### PR DESCRIPTION
This prevents a situation where the speedwagon's window would cause the
DesktopAppClient instance to reset the _lastDesktopApp value in between
the actual app has been launched and its window shown, preventint it
from getting maximized properly.

[endlessm/eos-shell#5377]