### PR TITLE
Update eos-coverage.m4 and add coverage test

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -40,6 +40,3 @@ EOS_JS_COVERAGE_FILES = $(shell python -c "import xml.etree.ElementTree as ET; i
 
 AM_CFLAGS = @EOS_COVERAGE_CFLAGS@
 AM_LDFLAGS = @EOS_COVERAGE_LDFLAGS@
-
-echo-cov-files:
-	@echo @EOS_JS_COVERAGE_LOG_FLAGS@

--- a/Makefile.am
+++ b/Makefile.am
@@ -33,10 +33,11 @@ distcheck-hook:
 
 AM_DISTCHECK_CONFIGURE_FLAGS = --enable-gtk-doc --enable-man
 
-# Pass resource paths to EOS_JS_COVERAGE_FILES
-EOS_JS_COVERAGE_FILES = $(shell python -c "import xml.etree.ElementTree as ET; import sys; tree = ET.parse('js/js-resources.gresource.xml'); map(sys.stdout.write, ['resource://org/gnome/shell/{0}\n'.format(e.text) for e in tree.getroot()[0]])")
-
-@EOS_COVERAGE_RULES@
-
 AM_CFLAGS = @EOS_COVERAGE_CFLAGS@
 AM_LDFLAGS = @EOS_COVERAGE_LDFLAGS@
+
+coverage-cobertura:
+	$(MAKE) $(AM_MAKEFLAGS) -f test/Makefile coverage-cobertura
+
+coverage-genhtml:
+	$(MAKE) $(AM_MAKEFLAGS) -f test/Makefile coverage-genhtml

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -42,8 +42,9 @@ EXTRA_DIST += $(TEST_MISC)
 
 TESTS = \
   $(JS_TESTS) \
+  run_coverage.coverage \
   $(NULL)
-TEST_EXTENSIONS = .js
+TEST_EXTENSIONS = .js .coverage
 
 @EOS_COVERAGE_RULES@
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -77,6 +77,3 @@ TESTS_ENVIRONMENT = \
 
 EXTRA_DIST += \
 	README.txt
-
-echo-am-js-log-flags:
-	@echo $(AM_JS_LOG_FLAGS)

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -49,7 +49,7 @@ TEST_EXTENSIONS = .js .coverage
 @EOS_COVERAGE_RULES@
 
 # Pass resource paths to EOS_JS_COVERAGE_FILES
-EOS_JS_COVERAGE_FILES = $(addprefix $(abs_top_srcdir)/js/,$(shell python -c "import xml.etree.ElementTree as ET; import sys; tree = ET.parse('../js/js-resources.gresource.xml'); map(sys.stdout.write, ['resource:///org/gnome/shell/{0}\n'.format(e.text) for e in tree.getroot()[0]])"))
+EOS_JS_COVERAGE_FILES = $(shell python -c "import xml.etree.ElementTree as ET; import sys; tree = ET.parse(\"$(abspath $(abs_top_srcdir)/js/js-resources.gresource.xml)\"); map(sys.stdout.write, ['resource:///org/gnome/shell/{0}\n'.format(e.text) for e in tree.getroot()[0]])")
 
 JS_LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) $(top_srcdir)/config/tap-driver.sh
 JS_LOG_DRIVER_FLAGS = --comments

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -78,3 +78,8 @@ TESTS_ENVIRONMENT = \
 
 EXTRA_DIST += \
 	README.txt
+
+clean-run-coverage:
+	rm -rf $(abs_top_builddir)/tests/run_coverage.coverage
+
+clean-local: clean-coverage clean-run-coverage


### PR DESCRIPTION
Not ready for merging yet.

eos-desktop is still tricky because of the use of recursive make. I've tried to remove the redundant rules and just embrace the recursiveness by making `coverage-lcov` and `coverage-cobertura` rules that just forward on to `tests/Makefile`.

For some reason adding `run_coverage.coverage` and even `tests/run_coverage.coverage` to `CLEANFILES` doesn't get it added to the list of stuff removed on `distclean` so I've had to add a separate rule for it.

[endlessm/eos-sdk#3303]