### PR TITLE
Makefile: Allow disabling of keybindings installation

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -142,8 +142,15 @@ PKG_CHECK_MODULES(CALENDAR_SERVER, libecal-1.2 >= $LIBECAL_MIN_VERSION libedatas
 AC_SUBST(CALENDAR_SERVER_CFLAGS)
 AC_SUBST(CALENDAR_SERVER_LIBS)
 
+AC_ARG_ENABLE([install-keybindings],
+              AS_HELP_STRING([--disable-install-keybindings], [Install keybindings globally]),
+              [install_gnome_keybindings=no],
+              [install_gnome_keybindings=yes])
+
 GNOME_KEYBINDINGS_KEYSDIR=`$PKG_CONFIG --variable keysdir gnome-keybindings`
 AC_SUBST([GNOME_KEYBINDINGS_KEYSDIR])
+AM_CONDITIONAL([INSTALL_GNOME_KEYBINDINGS],
+               [test "x$install_gnome_keybindings" = "xyes"])
 
 GOBJECT_INTROSPECTION_CHECK([$GOBJECT_INTROSPECTION_MIN_VERSION])
 

--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -43,11 +43,14 @@ gnome-shell-theme.gresource: gnome-shell-theme.gresource.xml $(resource_files)
 resourcedir = $(pkgdatadir)
 resource_DATA = gnome-shell-theme.gresource
 
-keysdir = $(GNOME_KEYBINDINGS_KEYSDIR)
 keys_in_files =					\
 	50-gnome-shell-system.xml.in		\
 	$(NULL)
 keys_DATA = $(keys_in_files:.xml.in=.xml)
+
+if INSTALL_GNOME_KEYBINDINGS
+keysdir = $(GNOME_KEYBINDINGS_KEYSDIR)
+endif
 
 gsettings_SCHEMAS = org.gnome.shell.gschema.xml
 


### PR DESCRIPTION
By default these keybindings install systemwide and it doesn't
make sense to change their install location. Requiring root access
to run make install is not desirable and so the user
should have been able to disable this.

[endlessm/eos-shell#5439]