### PR TITLE
appActivation: Don't clear the splash immediately when cancelled

### DIFF
--- a/src/shell-app.c
+++ b/src/shell-app.c
@@ -1121,13 +1121,14 @@ _shell_app_remove_window (ShellApp   *app,
     app->running_state->interesting_windows--;
 
   if (app->running_state->windows == NULL)
+    g_clear_pointer (&app->running_state, unref_running_state);
+
+  if (app->state != SHELL_APP_STATE_STARTING)
     {
-      g_clear_pointer (&app->running_state, unref_running_state);
-      shell_app_state_transition (app, SHELL_APP_STATE_STOPPED);
-    }
-  else
-    {
-      shell_app_sync_running_state (app);
+      if (app->running_state == NULL)
+        shell_app_state_transition (app, SHELL_APP_STATE_STOPPED);
+      else
+        shell_app_sync_running_state (app);
     }
 
   g_signal_emit (app, shell_app_signals[WINDOWS_CHANGED], 0);


### PR DESCRIPTION
Instead, wait for the app to transition to the RUNNING state before
clearing it out. Otherwise, after the user clicks the X on the splash
window, then the application would transition to STOPPED, which means
that we won't track when the application starts for real and try to
quit it.

[endlessm/eos-shell#5410]