### PR TITLE
panel: change name of panel to Taskbar in Ctrl+Alt+Tab

### DIFF
--- a/js/ui/panel.js
+++ b/js/ui/panel.js
@@ -372,7 +372,7 @@ const Panel = new Lang.Class({
         }));
 
         Main.layoutManager.panelBox.add(this.actor);
-        Main.ctrlAltTabManager.addGroup(this.actor, _("Top Bar"), 'emblem-system-symbolic',
+        Main.ctrlAltTabManager.addGroup(this.actor, _("Taskbar"), 'emblem-system-symbolic',
                                         { sortGroup: CtrlAltTab.SortGroup.TOP });
 
         Main.sessionMode.connect('updated', Lang.bind(this, this._updatePanel));


### PR DESCRIPTION
It's not at the top anymore.

[endlessm/eos-shell#5320]