### PR TITLE
shellDBus: don't mark remote method calls as interactive

### DIFF
--- a/js/ui/shellDBus.js
+++ b/js/ui/shellDBus.js
@@ -484,7 +484,7 @@ const AppStoreService = new Lang.Class({
 
     RemoveApplication: function(id) {
         if (!IconGridLayout.layout.iconIsFolder(id)) {
-            IconGridLayout.layout.removeIcon(id, true);
+            IconGridLayout.layout.removeIcon(id, false);
         }
     },
 
@@ -496,7 +496,7 @@ const AppStoreService = new Lang.Class({
 
     RemoveFolder: function(id) {
         if (IconGridLayout.layout.iconIsFolder(id)) {
-            IconGridLayout.layout.removeIcon(id, true);
+            IconGridLayout.layout.removeIcon(id, false);
         }
     },
 


### PR DESCRIPTION
Previously, it was not possible to remove an application from the store
that was not on the desktop.
Now that we have an "installed apps" page in the app store, this
operation is possible, and the app store will call into this DBus
method to make sure the desktop icon is deleted when an application is
removed.

In such case, we should not mark the operation as "interactive",
otherwise we'll get a shell notification with an Undo button that is not
intended.

While it's not exercised by the app store at the moment, also change the
same code for folder icons.

[endlessm/eos-shell#5836]