### PR TITLE
Shell: Fixed right-clicking eventing on the task bar

### DIFF
--- a/js/ui/appIconBar.js
+++ b/js/ui/appIconBar.js
@@ -382,6 +382,12 @@ const AppIconButton = new Lang.Class({
 
         if (button == Gdk.BUTTON_SECONDARY) {
             this._hideHoverState();
+
+            this._closeOtherMenus(BoxPointer.PopupAnimation.FULL);
+            if (this._menu.isOpen) {
+                this._menu.toggle(BoxPointer.PopupAnimation.FULL);
+            }
+
             this._rightClickMenu.open();
             return;
         }


### PR DESCRIPTION
We now ensure that other menus and window lists are closed before
showing the right-click menu to ensure we don't get strange menu stacking
visual artifacts.

[endlessm/eos-shell#3962]

