### PR TITLE
global: Filter out destroyed actors from get_window_actors()

### DIFF
--- a/src/shell-global.c
+++ b/src/shell-global.c
@@ -681,14 +681,21 @@ shell_global_get_display (ShellGlobal  *global)
  *
  * Gets the list of #MetaWindowActor for the plugin's screen
  *
- * Return value: (element-type Meta.WindowActor) (transfer none): the list of windows
+ * Return value: (element-type Meta.WindowActor) (transfer container): the list of windows
  */
 GList *
 shell_global_get_window_actors (ShellGlobal *global)
 {
+  GList *filtered = NULL;
+  GList *l;
+
   g_return_val_if_fail (SHELL_IS_GLOBAL (global), NULL);
 
-  return meta_get_window_actors (global->meta_screen);
+  for (l = meta_get_window_actors (global->meta_screen); l; l = l->next)
+    if (!meta_window_actor_is_destroyed (l->data))
+      filtered = g_list_prepend (filtered, l->data);
+
+  return g_list_reverse (filtered);
 }
 
 static void


### PR DESCRIPTION
All current code assumes that the list of window actors corresponds to the
list of windows; however as the list returned by meta_get_window_actors()
now includes actors during the destroy animation, that assumption breaks.

Eventually we should make everyone move to a more appropriate API, but
for now make it work again by returning a filtered list of "good"
window actors.

https://bugzilla.gnome.org/show_bug.cgi?id=735927

[endlessm/eos-shell#5575]