### PR TITLE
Shell: Fixed crash of login scripts when we exceed maximum login attempts

### DIFF
--- a/js/gdm/loginDialog.js
+++ b/js/gdm/loginDialog.js
@@ -741,7 +741,7 @@ const LoginDialog = new Lang.Class({
     _verificationFailed: function() {
         this._promptEntry.text = '';
 
-        if (this._user.get_password_hint().length > 0)
+        if (this._user && this._user.get_password_hint().length > 0)
             this._passwordHintButton.visible = true;
         else
             this._passwordHintButton.visible = false;


### PR DESCRIPTION
Previously when we would enter the password wrong too many times, the
user would get cleared an our hint-showing logic would break so now we
explicitly check that the value is there.

[endlessm/eos-shell#5930]
