### PR TITLE
theme: use points instead of pixels to set search entry font size

### DIFF
--- a/data/theme/gnome-shell.css
+++ b/data/theme/gnome-shell.css
@@ -915,7 +915,7 @@ StScrollBar StButton#vhandle:active {
     padding-right: 4px;
 
     font-family: lato, sans-serif;
-    font-size: 15px;
+    font-size: 11.5pt;
 
     color: #c5bcb6;
     selected-color: #333;


### PR DESCRIPTION
So that it responds to e.g. Large Text.

[endlessm/eos-shell#5952]