### PR TITLE
Shell/4681

### DIFF
--- a/data/40-gdm.rules
+++ b/data/40-gdm.rules
@@ -1,0 +1,8 @@
+polkit.addRule(function(action, subject) {
+        if (action.id == "org.freedesktop.accounts.user-administration" &&
+            (subject.user == "gdm" || subject.user == "Debian-gdm") &&
+            subject.local &&
+            subject.active) {
+                return polkit.Result.YES;
+        }
+});

--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -30,6 +30,9 @@ gnomesession_DATA = eos-shell.session gdm-eos-shell.session
 @INTLTOOL_DESKTOP_RULE@
 @INTLTOOL_XML_NOMERGE_RULE@
 
+rulesdir = $(sysconfdir)/polkit-1/rules.d
+rules_DATA = 40-gdm.rules
+
 introspectiondir = $(datadir)/dbus-1/interfaces
 introspection_DATA =				\
 	org.gnome.Shell.Screencast.xml		\
@@ -105,7 +108,8 @@ EXTRA_DIST =					\
 	org.gnome.shell.gschema.xml.in.in	\
 	eos-launch.desktop.in.in		\
 	gnome-shell-theme.gresource.xml		\
-	$(resource_files)
+	$(resource_files)			\
+	$(rules_DATA)
 
 CLEANFILES =					\
 	gdm-eos-shell.desktop.in		\

--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -1,3 +1,5 @@
+dist_pkgdata_DATA = vendor-customer-support.ini
+
 desktopdir=$(datadir)/applications
 desktop_DATA = eos-shell.desktop eos-shell-extension-prefs.desktop eos-link-feedback.desktop eos-launch.desktop
 

--- a/data/theme/gnome-shell.css
+++ b/data/theme/gnome-shell.css
@@ -2739,7 +2739,7 @@ StScrollBar StButton#vhandle:active {
 }
 
 .login-dialog-password-hint-label {
-    width: 40em;
+    width: 20em;
     color: #eeeeee;
     font-style: italic;
     font-size: 16px;
@@ -2839,8 +2839,13 @@ StScrollBar StButton#vhandle:active {
     background-color: rgba(102, 102, 102, 0.15);
 }
 
+.login-dialog-message-info {
+    width: 20em;
+}
+
 .login-dialog-message-warning {
     color: orange;
+    width: 20em;
 }
 
 .user-widget {

--- a/data/theme/gnome-shell.css
+++ b/data/theme/gnome-shell.css
@@ -2623,7 +2623,7 @@ StScrollBar StButton#vhandle:active {
     min-width: 350px;
 }
 
-.login-dialog-prompt-login-hint-message {
+.login-dialog-prompt-password-recovery-message {
     font-size: 12.5pt;
 }
 
@@ -2699,7 +2699,7 @@ StScrollBar StButton#vhandle:active {
     height: 64px;
 }
 
-.login-dialog-password-hint-link {
+.login-dialog-password-recovery-link {
     font-size: 12.5pt;
     font-weight: bold;
     color: #cccccc;
@@ -2714,8 +2714,8 @@ StScrollBar StButton#vhandle:active {
 
 .login-dialog-not-listed-button:focus .login-dialog-not-listed-label,
 .login-dialog-not-listed-button:hover .login-dialog-not-listed-label,
-.login-dialog-password-hint-button:focus .login-dialog-password-hint-link,
-.login-dialog-password-hint-button:hover .login-dialog-password-hint-link {
+.login-dialog-password-recovery-button:focus .login-dialog-password-recovery-link,
+.login-dialog-password-recovery-button:hover .login-dialog-password-recovery-link {
     color: #E8E8E8;
 }
 

--- a/data/vendor-customer-support.ini
+++ b/data/vendor-customer-support.ini
@@ -1,0 +1,8 @@
+[Customer Support]
+Email=support@endlessm.com
+Email[es]=ayuda@endlessm.com
+Email[pt]=ajuda@endlessm.com
+Phone=+1-415-980-4041
+Phone[es_GT]=+502-4761-1055 (Claro) o +502-3243-9866 (Tigo)
+Phone[es_MX]=+52-33-4170-3675
+Phone[pt_BR]=+55 (21) 9-9430-2859

--- a/js/Makefile.am
+++ b/js/Makefile.am
@@ -9,6 +9,7 @@ misc/config.js: misc/config.js.in Makefile
 	    -e "s|[@]GETTEXT_PACKAGE@|$(GETTEXT_PACKAGE)|g" \
 	    -e "s|[@]datadir@|$(datadir)|g" \
 	    -e "s|[@]libexecdir@|$(libexecdir)|g" \
+	    -e "s|[@]pkgdatadir@|$(pkgdatadir)|g" \
 	    -e "s|[@]sysconfdir@|$(sysconfdir)|g" \
                $< > $@
 

--- a/js/gdm/loginDialog.js
+++ b/js/gdm/loginDialog.js
@@ -925,7 +925,7 @@ const LoginDialog = new Lang.Class({
 
     _showPrompt: function(forSecret) {
         if (this._holdForAnswer)
-            throw new Error("Previous _showPrompt not yet finished");
+            throw new Error("Assertion failure, programmer error: previous _showPrompt not yet finished");
 
         this._sessionList.actor.hide();
         this._promptLabel.show();

--- a/js/gdm/loginDialog.js
+++ b/js/gdm/loginDialog.js
@@ -933,15 +933,20 @@ const LoginDialog = new Lang.Class({
 
         this._updateSignInButtonSensitivity(this._promptEntry.text.length > 0);
 
-        this._promptEntryTextChangedId =
-            this._promptEntry.clutter_text.connect('text-changed',
-                                                    Lang.bind(this, this._onPromptEntryTextChanged));
+        // This function can be called multiple times before we disconnect.
+        if (this._promptEntryTextChangedId == 0) {
+            this._promptEntryTextChangedId =
+                this._promptEntry.clutter_text.connect('text-changed',
+                                                        Lang.bind(this, this._onPromptEntryTextChanged));
+        }
 
-        this._promptEntryActivateId =
-            this._promptEntry.clutter_text.connect('activate', Lang.bind(this, function() {
-                this._holdForAnswer.release();
-                this._holdForAnswer = null;
-            }));
+        if (this._promptEntryActivateId == 0) {
+            this._promptEntryActivateId =
+                this._promptEntry.clutter_text.connect('activate', Lang.bind(this, function() {
+                    this._holdForAnswer.release();
+                    this._holdForAnswer = null;
+                }));
+        }
     },
 
     _updateSensitivity: function(sensitive) {

--- a/js/gdm/loginDialog.js
+++ b/js/gdm/loginDialog.js
@@ -1065,7 +1065,9 @@ const LoginDialog = new Lang.Class({
         this._promptEntry.set_text('');
         this._promptEntry.clutter_text.set_password_char('');
 
-        let tasks = [this._showPrompt,
+        let tasks = [function() {
+                         return this._showPrompt(false);
+                     },
 
                      function() {
                          let userName = this._promptEntry.get_text();

--- a/js/gdm/loginDialog.js
+++ b/js/gdm/loginDialog.js
@@ -1054,6 +1054,7 @@ const LoginDialog = new Lang.Class({
 
                      function() {
                          let userName = this._promptEntry.get_text();
+                         this._user = this._userManager.get_user(userName);
                          this._promptEntry.reactive = false;
                          return this._beginVerificationForUser(userName);
                      }];

--- a/js/gdm/loginDialog.js
+++ b/js/gdm/loginDialog.js
@@ -1111,8 +1111,7 @@ const LoginDialog = new Lang.Class({
     _handleIncorrectPasswordResetCode: function(verifier, serviceName) {
          this._updateSensitivity(true);
          this._promptEntry.set_text('');
-         this._promptMessage.set_text(
-             _("Your unlock code was incorrect. Please try again.").format(this._passwordResetCode));
+         this._promptMessage.set_text(_("Your unlock code was incorrect. Please try again."));
 
          // Use an idle so that _holdForAnswer gets cleared first.
          let id = Mainloop.idle_add(Lang.bind(this, function() {

--- a/js/gdm/loginDialog.js
+++ b/js/gdm/loginDialog.js
@@ -849,8 +849,7 @@ const LoginDialog = new Lang.Class({
     cancel: function() {
         if (this._verifyingUser)
             this._userVerifier.cancel();
-        else
-            this._reset();
+        this._reset();
     },
 
     _showPrompt: function(forSecret) {

--- a/js/gdm/loginDialog.js
+++ b/js/gdm/loginDialog.js
@@ -649,7 +649,10 @@ const LoginDialog = new Lang.Class({
         this._passwordResetButton.visible = false;
 
         this._promptMessage = new St.Label({ visible: false });
-        this._promptBox.add(this._promptMessage, { x_fill: true });
+        this._promptMessage.clutter_text.line_wrap = true;
+        this._promptMessage.clutter_text.ellipsize = Pango.EllipsizeMode.NONE;
+        this._promptBox.add(this._promptMessage, { expand: false,
+                                                   x_fill: false });
 
         this._promptLoginHint = new St.Label({ style_class: 'login-dialog-prompt-password-recovery-message' });
         this._promptLoginHint.hide();

--- a/js/gdm/loginDialog.js
+++ b/js/gdm/loginDialog.js
@@ -853,6 +853,9 @@ const LoginDialog = new Lang.Class({
     },
 
     _showPrompt: function(forSecret) {
+        if (this._holdForAnswer)
+            throw new Error("Previous _showPrompt not yet finished");
+
         this._sessionList.actor.hide();
         this._promptLabel.show();
         this._promptEntry.show();

--- a/js/gdm/loginDialog.js
+++ b/js/gdm/loginDialog.js
@@ -722,7 +722,10 @@ const LoginDialog = new Lang.Class({
         this._maybeShowPasswordResetButton();
     },
 
-    _readCustomerSupportData: function() {
+    _ensureCustomerSupportData: function() {
+        if (this._customerSupportPhoneNumber && this._customerSupportEmail)
+            return true;
+
         const CUSTOMER_SUPPORT_FILENAME = 'vendor-customer-support.ini';
         const CUSTOMER_SUPPORT_GROUP_NAME = 'Customer Support';
         const CUSTOMER_SUPPORT_KEY_EMAIL = 'Email';
@@ -747,10 +750,8 @@ const LoginDialog = new Lang.Class({
     },
 
     _maybeShowPasswordResetButton: function() {
-        if (!this._customerSupportPhoneNumber || !this._customerSupportEmail) {
-            if (!this._readCustomerSupportData())
-                return;
-        }
+        if (!this._ensureCustomerSupportData())
+            return;
 
         // There's got to be a better way to get our pid...?
         let credentials = new Gio.Credentials();

--- a/js/gdm/loginDialog.js
+++ b/js/gdm/loginDialog.js
@@ -616,8 +616,8 @@ const LoginDialog = new Lang.Class({
                               x_align: St.Align.START });
 
         let passwordHintLabel = new St.Label({ text: _("Show password hint"),
-                                               style_class: 'login-dialog-password-hint-link' });
-        this._passwordHintButton = new St.Button({ style_class: 'login-dialog-password-hint-button',
+                                               style_class: 'login-dialog-password-recovery-link' });
+        this._passwordHintButton = new St.Button({ style_class: 'login-dialog-password-recovery-button',
                                                    button_mask: St.ButtonMask.ONE | St.ButtonMask.THREE,
                                                    can_focus: true,
                                                    child: passwordHintLabel,
@@ -632,8 +632,8 @@ const LoginDialog = new Lang.Class({
         this._passwordHintButton.visible = false;
 
         let passwordResetLabel = new St.Label({ text: _("Forgot password?"),
-                                                style_class: 'login-dialog-password-hint-link' }); // FIXME rename style class
-        this._passwordResetButton = new St.Button({ style_class: 'login-dialog-password-hint-button', // FIXME rename style class
+                                                style_class: 'login-dialog-password-recovery-link' });
+        this._passwordResetButton = new St.Button({ style_class: 'login-dialog-password-recovery-button',
                                                     button_mask: St.ButtonMask.ONE | St.ButtonMask.THREE,
                                                     can_focus: true,
                                                     child: passwordResetLabel,
@@ -649,7 +649,7 @@ const LoginDialog = new Lang.Class({
         this._promptMessage = new St.Label({ visible: false });
         this._promptBox.add(this._promptMessage, { x_fill: true });
 
-        this._promptLoginHint = new St.Label({ style_class: 'login-dialog-prompt-login-hint-message' });
+        this._promptLoginHint = new St.Label({ style_class: 'login-dialog-prompt-password-recovery-message' });
         this._promptLoginHint.hide();
         this._promptBox.add(this._promptLoginHint);
 

--- a/js/gdm/loginDialog.js
+++ b/js/gdm/loginDialog.js
@@ -784,7 +784,6 @@ const LoginDialog = new Lang.Class({
     _reset: function() {
         this._userVerifier.clear();
 
-        this._passwordResetCode = null;
         this._updateSensitivity(true);
         this._promptMessage.hide();
         this._user = null;
@@ -793,8 +792,10 @@ const LoginDialog = new Lang.Class({
 
         if (this._disableUserList)
             this._hideUserListAndLogIn();
-        else
+        else if (!this._passwordResetCode)
             this._showUserList();
+
+        this._passwordResetCode = null;
     },
 
     _verificationFailed: function() {
@@ -1026,12 +1027,13 @@ const LoginDialog = new Lang.Class({
                              // else change 40-gdm.rules to allow this.
                              this._user.set_password_mode(AccountsService.UserPasswordMode.SET_AT_LOGIN);
 
-                             // FIXME: Go straight to setting the new password. Don't reset.
-                             //this._reset();
+                             let user = this._user;
+                             this._userVerifier.cancel();
+                             this._reset();
+                             this._user = user;
 
-                             //this._userVerifier.clear();
-                             this._beginVerificationForUser(this._user.get_user_name());
-                             //this._passwordResetCode = null;
+                             this._beginVerificationForUser(user.get_user_name());
+                             this._passwordResetCode = null;
                          } else {
                              // FIXME: Show a message when the unlock code is incorrect. Don't reset.
                              //this._passwordResetCode = null;

--- a/js/gdm/loginDialog.js
+++ b/js/gdm/loginDialog.js
@@ -792,6 +792,7 @@ const LoginDialog = new Lang.Class({
         checksum.update(ByteArray.fromString(resetCode));
 
         let unlockCode = checksum.get_string();
+        // Remove everything except digits.
         unlockCode = unlockCode.replace(/\D/g, '');
         unlockCode = unlockCode.slice(0, _RESET_CODE_LENGTH);
 
@@ -959,6 +960,7 @@ const LoginDialog = new Lang.Class({
         if (this._passwordResetCode == null) {
             this._updateSignInButtonSensitivity(this._promptEntry.text.length > 0);
         } else {
+            // Password unlock code must contain the right number of digits, and only digits.
             this._updateSignInButtonSensitivity(
                 this._promptEntry.text.length == _RESET_CODE_LENGTH &&
                 this._promptEntry.text.search(/\D/) == -1);

--- a/js/gdm/loginDialog.js
+++ b/js/gdm/loginDialog.js
@@ -837,6 +837,7 @@ const LoginDialog = new Lang.Class({
 
     _reset: function() {
         this._userVerifier.clear();
+        this._userVerifier.resetFailCounter();
 
         this._updateSensitivity(true);
         this._promptMessage.hide();

--- a/js/gdm/loginDialog.js
+++ b/js/gdm/loginDialog.js
@@ -842,14 +842,13 @@ const LoginDialog = new Lang.Class({
         this._promptMessage.hide();
         this._user = null;
         this._passwordHintButton.visible = false;
+        this._passwordResetCode = null;
         this._verifyingUser = false;
 
         if (this._disableUserList)
             this._hideUserListAndLogIn();
-        else if (!this._passwordResetCode)
+        else
             this._showUserList();
-
-        this._passwordResetCode = null;
 
         if (this._holdForAnswer) {
             this._holdForAnswer.release();

--- a/js/gdm/loginDialog.js
+++ b/js/gdm/loginDialog.js
@@ -1113,6 +1113,10 @@ const LoginDialog = new Lang.Class({
     },
 
     _onAnswerProvided: function(verifier, serviceName) {
+         // Cancelled?
+         if (!this._verifyingUser)
+             return;
+
          if (this._passwordResetCode == null)
             this._respondToSessionWorker(serviceName);
          else if (this._promptEntry.get_text() == this._computeUnlockCode(this._passwordResetCode))
@@ -1133,8 +1137,7 @@ const LoginDialog = new Lang.Class({
                      },
 
                      function() {
-                         if (this._user)
-                             this._onAnswerProvided(verifier, serviceName);
+                         this._onAnswerProvided(verifier, serviceName);
                      }];
 
         let batch = new Batch.ConsecutiveBatch(this, tasks);

--- a/js/gdm/loginDialog.js
+++ b/js/gdm/loginDialog.js
@@ -803,9 +803,10 @@ const LoginDialog = new Lang.Class({
 
         this._promptMessage.set_text(
             // Translators: Password reset. The first %s is an email, the second is one or more phone numbers.
-            _("Please contact customer support at %s or %s. Your verification code is %s.").format(this._customerSupportEmail,
-                                                                                                   this._customerSupportPhoneNumber,
-                                                                                                   this._passwordResetCode));
+            _("Please inform customer support of your verification code %s by calling %s or emailing %s. The code will remain valid until you click Cancel or turn off your computer.").format(
+                this._passwordResetCode,
+                this._customerSupportPhoneNumber,
+                this._customerSupportEmail));
 
         // Translators: Button on login dialog, after clicking Forgot Password?
         this._signInButton.set_label(_("Reset Password"));

--- a/js/gdm/loginDialog.js
+++ b/js/gdm/loginDialog.js
@@ -799,9 +799,13 @@ const LoginDialog = new Lang.Class({
     },
 
     _verificationFailed: function() {
+        // Nothing to do if we were just reset after too many failed verifications.
+        if (!this._user)
+            return;
+
         this._promptEntry.text = '';
 
-        if (this._user && this._user.get_password_hint().length > 0)
+        if (this._user.get_password_hint().length > 0) {
             this._passwordHintButton.visible = true;
         } else {
             this._passwordHintButton.visible = false;

--- a/js/gdm/loginDialog.js
+++ b/js/gdm/loginDialog.js
@@ -641,12 +641,12 @@ const LoginDialog = new Lang.Class({
                                                     child: passwordResetLabel,
                                                     reactive: true,
                                                     x_align: St.Align.START,
-                                                    x_fill: true });
+                                                    x_fill: true,
+                                                    visible: false });
         this._promptBox.add(this._passwordResetButton,
                             { x_fill: false,
                               x_align: St.Align.START });
         this._passwordResetButton.connect('clicked', Lang.bind(this, this._showPasswordResetPrompt));
-        this._passwordResetButton.visible = false;
 
         this._promptMessage = new St.Label({ visible: false });
         this._promptMessage.clutter_text.line_wrap = true;

--- a/js/gdm/loginDialog.js
+++ b/js/gdm/loginDialog.js
@@ -842,6 +842,7 @@ const LoginDialog = new Lang.Class({
         this._promptMessage.hide();
         this._user = null;
         this._passwordHintButton.visible = false;
+        this._passwordResetButton.visible = false;
         this._passwordResetCode = null;
         this._verifyingUser = false;
 

--- a/js/gdm/loginDialog.js
+++ b/js/gdm/loginDialog.js
@@ -723,11 +723,21 @@ const LoginDialog = new Lang.Class({
     },
 
     _readCustomerSupportData: function() {
+        const CUSTOMER_SUPPORT_FILENAME = 'vendor-customer-support.ini';
+        const CUSTOMER_SUPPORT_GROUP_NAME = 'Customer Support';
+        const CUSTOMER_SUPPORT_KEY_EMAIL = 'Email';
+        const CUSTOMER_SUPPORT_KEY_PHONE = 'Phone';
+
         try {
             let keyFile = new GLib.KeyFile();
-            keyFile.load_from_file(Config.PKGDATADIR + '/vendor-customer-support.ini', GLib.KeyFileFlags.NONE);
-            this._customerSupportEmail = keyFile.get_locale_string('Customer Support', 'Email', null);
-            this._customerSupportPhoneNumber = keyFile.get_locale_string('Customer Support', 'Phone', null);
+            keyFile.load_from_file(Config.PKGDATADIR + '/' + CUSTOMER_SUPPORT_FILENAME,
+                                   GLib.KeyFileFlags.NONE);
+            this._customerSupportEmail = keyFile.get_locale_string(CUSTOMER_SUPPORT_GROUP_NAME,
+                                                                   CUSTOMER_SUPPORT_KEY_EMAIL,
+                                                                   null);
+            this._customerSupportPhoneNumber = keyFile.get_locale_string(CUSTOMER_SUPPORT_GROUP_NAME,
+                                                                         CUSTOMER_SUPPORT_KEY_PHONE,
+                                                                         null);
         } catch (e) {
             logError(e, 'Failed to read customer support data');
             return false;

--- a/js/gdm/loginDialog.js
+++ b/js/gdm/loginDialog.js
@@ -1086,9 +1086,7 @@ const LoginDialog = new Lang.Class({
              this._user.set_password_mode(AccountsService.UserPasswordMode.SET_AT_LOGIN);
              let user = this._user;
              this._userVerifier.cancel();
-             this._reset();
              this._user = user;
-
              this._beginVerificationForUser(user.get_user_name());
              this._passwordResetCode = null;
          } else {

--- a/js/gdm/util.js
+++ b/js/gdm/util.js
@@ -175,6 +175,10 @@ const ShellUserVerifier = new Lang.Class({
         this._clearMessageQueue();
     },
 
+    resetFailCounter: function() {
+        this._failCounter = 0;
+    },
+
     answerQuery: function(serviceName, answer) {
         if (!this._userVerifier.hasPendingMessages) {
             this._userVerifier.call_answer_query(serviceName, answer, this._cancellable, null);

--- a/js/gdm/util.js
+++ b/js/gdm/util.js
@@ -126,6 +126,15 @@ const ShellUserVerifier = new Lang.Class({
     },
 
     begin: function(userName, hold) {
+        // We need to make sure the original _userVerifier is properly destroyed
+        // before creating a new one, so that we don't report messages from the
+        // session worker multiple times. But we must not clear the message
+        // queue, because it still has pending the failure message.
+        if (this._userVerifier) {
+            this._userVerifier.run_dispose();
+            this._userVerifier = null;
+        }
+
         this._cancellable = new Gio.Cancellable();
         this._hold = hold;
         this._userName = userName;

--- a/js/gdm/util.js
+++ b/js/gdm/util.js
@@ -146,8 +146,10 @@ const ShellUserVerifier = new Lang.Class({
         if (this._cancellable)
             this._cancellable.cancel();
 
-        if (this._userVerifier)
+        if (this._userVerifier) {
             this._userVerifier.call_cancel_sync(null);
+            this.clear();
+        }
     },
 
     clear: function() {

--- a/js/misc/config.js.in
+++ b/js/misc/config.js.in
@@ -14,3 +14,5 @@ const LOCALEDIR = '@datadir@/locale';
 const DATADIR = '@datadir@';
 const LIBEXECDIR = '@libexecdir@';
 const SYSCONFDIR = '@sysconfdir@';
+/* subdirectories under standard directories */
+const PKGDATADIR = '@pkgdatadir@';

--- a/tools/password-unlocker.js
+++ b/tools/password-unlocker.js
@@ -1,0 +1,35 @@
+#!/usr/bin/gjs
+
+// This script computes the "secret code" to perform a password reset.
+// The first argument to the script should be the "verification code"
+// displayed by the login screen.
+
+const ByteArray = imports.byteArray;
+const Format = imports.format;
+const Gio = imports.gi.Gio;
+const GLib = imports.gi.GLib;
+const Lang = imports.lang;
+
+const RESET_CODE_LENGTH = 7;
+
+String.prototype.format = Format.format;
+
+if (ARGV.length != 1) {
+    print('This script should be called with a reset code as the first and only argument');
+} else if (ARGV[0].length != RESET_CODE_LENGTH) {
+    print('Invalid reset code %s; valid reset codes have length %d'.format(ARGV[0], RESET_CODE_LENGTH));
+} else if (ARGV[0].search(/\D/) != -1) {
+    print('Invalid reset code %s; code should only contain digits'.format(ARGV[0]));
+} else {
+    let checksum = new GLib.Checksum(GLib.ChecksumType.MD5);
+    checksum.update(ByteArray.fromString(ARGV[0]));
+
+    let unlockCode = checksum.get_string();
+    unlockCode = unlockCode.replace(/\D/g, '');
+    unlockCode = unlockCode.slice(0, RESET_CODE_LENGTH);
+
+    while (unlockCode.length < RESET_CODE_LENGTH)
+        unlockCode += '0';
+
+    print(unlockCode);
+}


### PR DESCRIPTION
Add support for password reset. This adds a Forgot password? button to the login screen, visible after mistyping a password and clicking the password hint button if a password hint is set, immediately after mistyping the password otherwise. The user is given a random code and prompted to contact customer support at a region-specific email address or phone number. If the login screen presents the random code 1234567, compute the corresponding unlock code with `tools/password-unlocker 1234567`.

I still need to fix the following user experience issues:

endlessm/eos-shell#5894
endlessm/eos-shell#5895
endlessm/eos-shell#5966