### PR TITLE
Move 40-gdm.rules to $(datadir)

### DIFF
--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -32,7 +32,7 @@ gnomesession_DATA = eos-shell.session gdm-eos-shell.session
 @INTLTOOL_DESKTOP_RULE@
 @INTLTOOL_XML_NOMERGE_RULE@
 
-rulesdir = $(sysconfdir)/polkit-1/rules.d
+rulesdir = $(datadir)/polkit-1/rules.d
 rules_DATA = 40-gdm.rules
 
 introspectiondir = $(datadir)/dbus-1/interfaces


### PR DESCRIPTION
cosimoc:  mcatanzaro, on second thought I don't think the rules file
should go in /etc/polkit-1/rules.d
cosimoc:  should go into /usr/share/polkit-1/rules.d instead
cosimoc:  it's not a distributor override - that's what the /etc rules
are for AFAIU
[endlessm/eos-shell#4681]