### PR TITLE
Issue/5927

### DIFF
--- a/js/ui/dateMenu.js
+++ b/js/ui/dateMenu.js
@@ -43,7 +43,6 @@ const DateMenuButton = new Lang.Class({
         let item;
         let hbox;
         let vbox;
-        let scrollview;
 
         let menuAlignment = 0.25;
         if (Clutter.get_default_text_direction() == Clutter.TextDirection.RTL)
@@ -58,11 +57,8 @@ const DateMenuButton = new Lang.Class({
         this._clockDisplay = new St.Label();
         this.actor.add_actor(this._clockDisplay);
 
-        scrollview = new St.ScrollView({x_fill: true, y_fill: true})
-        this.menu.addActor(scrollview);
-
         hbox = new St.BoxLayout({name: 'calendarArea' });
-        scrollview.add_actor(hbox);
+        this.menu.addActor(hbox);
 
         // Fill up the first column
 

--- a/js/ui/popupMenu.js
+++ b/js/ui/popupMenu.js
@@ -1112,7 +1112,7 @@ const PopupMenu = new Lang.Class({
     Extends: PopupMenuBase,
 
     _init: function(sourceActor, arrowAlignment, arrowSide) {
-        this.parent(sourceActor, 'popup-menu-content');
+        this.parent(sourceActor);
 
         this._arrowAlignment = arrowAlignment;
         this._arrowSide = arrowSide;
@@ -1125,10 +1125,10 @@ const PopupMenu = new Lang.Class({
         this.actor._delegate = this;
         this.actor.style_class = 'popup-menu-boxpointer';
 
-        this._boxWrapper = new Shell.GenericContainer();
-        this._boxWrapper.connect('get-preferred-width', Lang.bind(this, this._boxGetPreferredWidth));
-        this._boxWrapper.connect('get-preferred-height', Lang.bind(this, this._boxGetPreferredHeight));
-        this._boxWrapper.connect('allocate', Lang.bind(this, this._boxAllocate));
+        this._boxWrapper = new St.ScrollView({ hscrollbar_policy: Gtk.PolicyType.NEVER,
+                                               vscrollbar_policy: Gtk.PolicyType.AUTOMATIC,
+                                               overlay_scrollbars: true });
+        this._boxWrapper.add_style_class_name('popup-menu-content');
         this._boxPointer.bin.set_child(this._boxWrapper);
         this._boxWrapper.add_actor(this.box);
         this.actor.add_style_class_name('popup-menu');
@@ -1137,22 +1137,6 @@ const PopupMenu = new Lang.Class({
         this.actor.reactive = true;
 
         this._childMenus = [];
-    },
-
-    _boxGetPreferredWidth: function (actor, forHeight, alloc) {
-        let columnWidths = this.getColumnWidths();
-        this.setColumnWidths(columnWidths);
-
-        // Now they will request the right sizes
-        [alloc.min_size, alloc.natural_size] = this.box.get_preferred_width(forHeight);
-    },
-
-    _boxGetPreferredHeight: function (actor, forWidth, alloc) {
-        [alloc.min_size, alloc.natural_size] = this.box.get_preferred_height(forWidth);
-    },
-
-    _boxAllocate: function (actor, box, flags) {
-        this.box.allocate(box, flags);
     },
 
     setArrowOrigin: function(origin) {

--- a/js/ui/status/power.js
+++ b/js/ui/status/power.js
@@ -73,7 +73,12 @@ const Indicator = new Lang.Class({
 
         this._batteryItem = new PopupMenu.PopupMenuItem('', { reactive: false });
         this._primaryPercentage = new St.Label({ style_class: 'popup-battery-percentage' });
-        this._batteryItem.addActor(this._primaryPercentage, { align: St.Align.END });
+
+        /* The St.Bin below is used to properly make it end-aligned */
+        let bin = new St.Bin({ x_align: St.Align.END });
+        bin.child = this._primaryPercentage;
+
+        this._batteryItem.addActor(bin, { expand: true, span: -1, align: St.Align.END });
         this.menu.addMenuItem(this._batteryItem);
 
         this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
@@ -196,7 +201,12 @@ const DeviceItem = new Lang.Class({
 
         let percentLabel = new St.Label({ text: C_("percent of battery remaining", "%d%%").format(Math.round(percentage)),
                                           style_class: 'popup-battery-percentage' });
-        this.addActor(percentLabel, { align: St.Align.END });
+
+        /* The St.Bin below is used to properly make it end-aligned */
+        let bin = new St.Bin({ x_align: St.Align.END });
+        bin.child = percentLabel;
+
+        this.addActor(bin, { expand: true, span: -1, align: St.Align.END });
         //FIXME: ideally we would like to expose this._label and percentLabel
         this.actor.label_actor = percentLabel;
     },


### PR DESCRIPTION
There are these 3 commits, which:
- Revert the work done on the Calendar popover menu
- Make *all* menus scrollable in smaller screens
- Fix the power menu, which was in fact lucky code.

[endlessm/eos-shell#5927]