### PR TITLE
network: fix wifi icons alignment

### DIFF
--- a/js/ui/status/network.js
+++ b/js/ui/status/network.js
@@ -122,18 +122,21 @@ const NMNetworkMenuItem = new Lang.Class({
         this._label = new St.Label({ text: title });
         this.actor.label_actor = this._label;
         this.addActor(this._label);
-        this._icons = new St.BoxLayout({ style_class: 'nm-menu-item-icons' });
+        this._icons = new St.Bin({ x_align: St.Align.END });
         this.addActor(this._icons, { align: St.Align.END });
+
+        let hbox = new St.BoxLayout({ style_class: 'nm-menu-item-icons' });
+        this._icons.child = hbox;
 
         this._signalIcon = new St.Icon({ icon_name: this._getIcon(),
                                          style_class: 'popup-menu-icon' });
-        this._icons.add_actor(this._signalIcon);
+        hbox.add_actor(this._signalIcon);
 
         this._secureIcon = new St.Icon({ style_class: 'popup-menu-icon' });
         if (this.bestAP._secType != NMAccessPointSecurity.UNKNOWN &&
             this.bestAP._secType != NMAccessPointSecurity.NONE)
             this._secureIcon.icon_name = 'network-wireless-encrypted-symbolic';
-        this._icons.add_actor(this._secureIcon);
+        hbox.add_actor(this._secureIcon);
     },
 
     updateBestAP: function(ap) {


### PR DESCRIPTION
Add the wifi icons in a end-aligned StBin so they are correctly positioned. This is the same approach taken to fix the power menu alignment.

[endlessm/eos-shell#6154]