### PR TITLE
loginDialog: Use single quotes for non-translatable strings

### DIFF
--- a/js/gdm/loginDialog.js
+++ b/js/gdm/loginDialog.js
@@ -925,7 +925,7 @@ const LoginDialog = new Lang.Class({
 
     _showPrompt: function(forSecret) {
         if (this._holdForAnswer)
-            throw new Error("Assertion failure, programmer error: previous _showPrompt not yet finished");
+            throw new Error('Assertion failure, programmer error: previous _showPrompt not yet finished');
 
         this._sessionList.actor.hide();
         this._promptLabel.show();


### PR DESCRIPTION
Not really sure the distinction between single quotes and double quotes
makes sense, but let not me be the one to have messed it up.