### PR TITLE
issue/5929

### DIFF
--- a/data/theme/gnome-shell.css
+++ b/data/theme/gnome-shell.css
@@ -927,6 +927,10 @@ StScrollBar StButton#vhandle:active {
     -minimum-vpadding: 48px;
 }
 
+#searchEntry.low-resolution {
+    -minimum-vpadding: 24px;
+}
+
 #searchEntry:rtl {
     padding-left: 4px;
     padding-right: 8px;
@@ -1166,6 +1170,10 @@ StScrollBar StButton#vhandle:active {
 
 .all-apps {
     -natural-padding-top: 25px;
+}
+
+.all-apps.low-resolution {
+    -natural-padding-top: 15px;
 }
 
 .search-display > StBoxLayout,

--- a/data/theme/gnome-shell.css
+++ b/data/theme/gnome-shell.css
@@ -1123,7 +1123,7 @@ StScrollBar StButton#vhandle:active {
     -shell-grid-vertical-item-size: 118px;
 }
 
-.icon-grid.composite-mode {
+.icon-grid.low-resolution {
     -shell-grid-horizontal-item-size: 104px;
     -shell-grid-vertical-item-size: 104px;
 }

--- a/js/ui/iconGrid.js
+++ b/js/ui/iconGrid.js
@@ -477,11 +477,12 @@ const IconGrid = new Lang.Class({
         this.saturation = new Shell.GridDesaturateEffect({ factor: 0,
                                                            enabled: false });
         this.actor.add_effect(this.saturation);
+        this._lowResolutionMode = false;
 
         /* Setup the composite mode of the grid */
-        Main.layoutManager.connect('monitors-changed', Lang.bind(this, this._updateCompositeMode));
+        Main.layoutManager.connect('monitors-changed', Lang.bind(this, this._updateLowResolutionMode));
 
-        this._updateCompositeMode();
+        this._updateLowResolutionMode();
     },
 
     _getPreferredWidth: function (grid, forHeight, alloc) {
@@ -956,28 +957,21 @@ const IconGrid = new Lang.Class({
         return [dropIdx, cursorLocation];
     },
 
-    _updateCompositeMode: function() {
-        /* Given that the height of the widget varies according to the
-         * number of icons, we only check the width here.
+    _updateLowResolutionMode: function() {
+        if (this._lowResolutionMode == Main.lowResolutionDisplay)
+            return;
+
+        this._lowResolutionMode = Main.lowResolutionDisplay;
+
+        /* When we're running on small screens, to make it fit 5 columns
+         * on the available space, we shall reduce the icon size. Do
+         * this by adding (or removing, in case the screen is big enough)
+         * the .low-resolution style class.
          */
-        this.compositeMode = Main.layoutManager.primaryMonitor &&
-                             Main.layoutManager.primaryMonitor.width < 800;
-    },
-
-    set compositeMode(mode) {
-        if (this._compositeMode != mode) {
-            this._compositeMode = mode;
-
-            /* When we're running on small screens, to make it fit 5 columns
-             * on the available space, we shall reduce the icon size. Do
-             * this by adding (or removing, in case the screen is big enough)
-             * the .composite-mode style class.
-             */
-            if (mode) {
-                this.actor.add_style_class_name('composite-mode');
-            } else {
-                this.actor.remove_style_class_name('composite-mode');
-            }
+        if (this._lowResolutionMode) {
+            this.actor.add_style_class_name('low-resolution');
+        } else {
+            this.actor.remove_style_class_name('low-resolution');
         }
     }
 });

--- a/js/ui/main.js
+++ b/js/ui/main.js
@@ -42,6 +42,8 @@ const Util = imports.misc.util;
 
 const OVERRIDES_SCHEMA = 'org.gnome.shell.overrides';
 const DEFAULT_BACKGROUND_COLOR = Clutter.Color.from_pixel(0x2e3436ff);
+const LOW_RESOLUTION_WIDTH = 800;
+const LOW_RESOLUTION_HEIGHT = 600;
 
 let appStore = null;
 let componentManager = null;
@@ -71,6 +73,7 @@ let keyboard = null;
 let layoutManager = null;
 let workspaceMonitor = null;
 let desktopAppClient = null;
+let lowResolutionDisplay = false;
 let _startDate;
 let _defaultCssStylesheet = null;
 let _cssStylesheet = null;
@@ -141,6 +144,12 @@ function _initializeUI() {
 
     // Setup the stage hierarchy early
     layoutManager = new Layout.LayoutManager();
+
+    // Track the primary display and check whether it's
+    // running on a display with low resolution.
+    layoutManager.connect("display-changed", _updateLowResolution);
+
+    _updateLowResolution();
 
     // Various parts of the codebase still refers to Main.uiGroup
     // instead using the layoutManager.  This keeps that code
@@ -216,6 +225,12 @@ function _initializeUI() {
             keybindingMode = Shell.KeyBindingMode.NORMAL;
         }
     });
+}
+
+function _updateLowResolution() {
+    lowResolutionDisplay = layoutManager.primaryMonitor &&
+                           (layoutManager.primaryMonitor.width < LOW_RESOLUTION_WIDTH ||
+                            layoutManager.primaryMonitor.height < LOW_RESOLUTION_HEIGHT);
 }
 
 let _workspaces = [];

--- a/js/ui/viewSelector.js
+++ b/js/ui/viewSelector.js
@@ -65,6 +65,11 @@ const ViewsDisplayLayout = new Lang.Class({
 
         this._heightAboveEntry = 0;
         this.searchResultsTween = 0;
+        this._lowResolutionMode = false;
+
+        /* Setup composite mode */
+        Main.layoutManager.connect('monitors-changed', Lang.bind(this, this._updateLowResolutionMode));
+        this._updateLowResolutionMode();
     },
 
     _onStyleChanged: function() {
@@ -145,6 +150,26 @@ const ViewsDisplayLayout = new Lang.Class({
             searchResultsBox.y1 = entryBox.y2;
             searchResultsBox.y2 = searchResultsBox.y1 + searchResultsHeight;
             this._searchResultsActor.allocate(searchResultsBox, flags);
+        }
+    },
+
+    _updateLowResolutionMode: function() {
+        if (this._lowResolutionMode == Main.lowResolutionDisplay)
+            return;
+
+        this._lowResolutionMode = Main.lowResolutionDisplay;
+
+        /* When running on small screens, to make it fit 3 rows of icons,
+         * reduce the space above and below the search entry by adding (or
+         * removing, in case the screen is big enough) the .composite-mode
+         * style class.
+         */
+        if (this._lowResolutionMode) {
+            this._entry.add_style_class_name('low-resolution');
+            this._allViewActor.add_style_class_name('low-resolution');
+        } else {
+            this.entry.remove_style_class_name('low-resolution');
+            this._allViewActor.remove_style_class_name('low-resolution');
         }
     }
 });


### PR DESCRIPTION
When the primary monitor is running on composite mode,
we should make it fit 3 rows before exposing the scroll
bar.

To fix that, add the .composite-mode style classes when
the primary monitor is too small.

[endlessm/eos-shell#5929]