### PR TITLE
appDisplay: Fix app folder close button's position

### DIFF
--- a/js/ui/appDisplay.js
+++ b/js/ui/appDisplay.js
@@ -1687,6 +1687,7 @@ const AppFolderPopup = new Lang.Class({
 
         this._boxPointer.actor.bind_property('opacity', this.closeButton, 'opacity',
                                              GObject.BindingFlags.SYNC_CREATE);
+        this._boxPointer.bin.connect('realize', Lang.bind(this, this._adjustCloseButton));
     },
 
     toggle: function() {
@@ -1696,9 +1697,18 @@ const AppFolderPopup = new Lang.Class({
             this.popup();
     },
 
+    _adjustCloseButton: function() {
+        // When the popup has its arrow on top, the close button needs to be
+        // positioned a bit lower so it's placed on the boxPointer corner's edge
+        const marginTop = this._boxPointer.bin.get_y();
+        this.closeButton.set_y(this.closeButton.get_y() + marginTop);
+    },
+
     popup: function() {
         if (this._isOpen)
             return;
+
+        this._adjustCloseButton();
 
         this.actor.show();
 


### PR DESCRIPTION
The app folder's close button is positioned on the top right of the
folder's boxPointer. However, when the boxPointer has its arrow on
top (when the folder pops downwards), its box will be positioned lower
and thus the close button appears a bit higher than it should be.

These changes fix that problem by placing the close button taking
into account the position of the boxPointer.

[endlessm/eos-shell#6263]