### PR TITLE
issue/5929

### DIFF
--- a/data/theme/gnome-shell.css
+++ b/data/theme/gnome-shell.css
@@ -932,7 +932,7 @@ StScrollBar StButton#vhandle:active {
 }
 
 #searchEntry.low-resolution {
-    -minimum-vpadding: 24px;
+    -minimum-vpadding: 20px;
 }
 
 #searchEntry:rtl {


### PR DESCRIPTION
After reverting the icon size reduce on low resolution
screens on endlessm/eos-shell#5928, the proposed solution
for making 3 rows visible didn't apply anymore.

Fix that by reducing the top padding on All View 5px more.

[endlessm/eos-shell#5929]