### PR TITLE
Show horizontal scrollbars for PopupMenu when needed

### DIFF
--- a/data/theme/gnome-shell.css
+++ b/data/theme/gnome-shell.css
@@ -183,6 +183,10 @@ StScrollBar StButton#vhandle:active {
  * override .popup-menu.font-size, everything else will scale with it.
  */
 .popup-menu-content {
+    padding: 0em 0em;
+}
+
+.popup-menu-content-box {
     padding: 1em 0em;
 }
 

--- a/js/ui/dateMenu.js
+++ b/js/ui/dateMenu.js
@@ -85,7 +85,6 @@ const DateMenuButton = new Lang.Class({
         vbox.add(this._calendar.actor);
 
         let separator = new PopupMenu.PopupSeparatorMenuItem();
-        separator.setColumnWidths(1);
         vbox.add(separator.actor, {y_align: St.Align.END, expand: true, y_fill: false});
 
         this._openCalendarItem = new PopupMenu.PopupMenuItem(_("Open Calendar"));

--- a/js/ui/popupMenu.js
+++ b/js/ui/popupMenu.js
@@ -1125,8 +1125,9 @@ const PopupMenu = new Lang.Class({
         this.actor._delegate = this;
         this.actor.style_class = 'popup-menu-boxpointer';
 
+        // We will manually control when and how we show the scrollbars.
         this._boxWrapper = new St.ScrollView({ hscrollbar_policy: Gtk.PolicyType.NEVER,
-                                               vscrollbar_policy: Gtk.PolicyType.AUTOMATIC,
+                                               vscrollbar_policy: Gtk.PolicyType.NEVER,
                                                overlay_scrollbars: true });
         this._boxWrapper.add_style_class_name('popup-menu-content');
         this._boxPointer.bin.set_child(this._boxWrapper);
@@ -1169,6 +1170,41 @@ const PopupMenu = new Lang.Class({
         this.emit('child-menu-removed', menu);
     },
 
+    _showScrollbarIfNeeded: function(orientation) {
+        let minSize;
+        let naturalSize;
+        let availableSpace;
+
+        // The BoxPointer class uses the distance from the source object to the
+        // box also as a padding to separate the box from the edges of the work
+        // area, which we need to calculate whether we need to force scrollbars.
+        let boxPointerThemeNode = this._boxPointer.actor.get_theme_node();
+        let marginToEdge = boxPointerThemeNode.get_length('-arrow-rise');
+
+        // We need the workspace area (from Mutter) to check the available space.
+        let workArea = Main.layoutManager.getWorkAreaForMonitor(Main.layoutManager.primaryIndex);
+
+        if (orientation == Clutter.Orientation.HORIZONTAL) {
+            [minSize, naturalSize] = this.actor.get_preferred_width(-1);
+            availableSpace = workArea.width - (2 * marginToEdge);
+            if (naturalSize > availableSpace) {
+                this._boxWrapper.hscrollbar_policy = Gtk.PolicyType.ALWAYS;
+                this.actor.set_width(availableSpace);
+            } else {
+                this._boxWrapper.hscrollbar_policy = Gtk.PolicyType.NEVER;
+            }
+        } else {
+            [minSize, naturalSize] = this.actor.get_preferred_height(-1);
+            availableSpace = workArea.height - marginToEdge;
+            if (naturalSize > availableSpace) {
+                this._boxWrapper.vscrollbar_policy = Gtk.PolicyType.ALWAYS;
+                this.actor.set_height(availableSpace);
+            } else {
+                this._boxWrapper.vscrollbar_policy = Gtk.PolicyType.NEVER;
+            }
+        }
+    },
+
     open: function(animate) {
         if (this.isOpen)
             return;
@@ -1177,6 +1213,9 @@ const PopupMenu = new Lang.Class({
             return;
 
         this.isOpen = true;
+
+        this._showScrollbarIfNeeded(Clutter.Orientation.VERTICAL);
+        this._showScrollbarIfNeeded(Clutter.Orientation.HORIZONTAL);
 
         this._boxPointer.setPosition(this.sourceActor, this._arrowAlignment);
         this._boxPointer.show(animate);
@@ -1196,6 +1235,13 @@ const PopupMenu = new Lang.Class({
 
         if (this._boxPointer.actor.visible)
             this._boxPointer.hide(animate);
+
+        // We might have changed the dimensions of the popup to something different
+        // than the preferred ones if needed to force scrollbars, so we need to reset
+        // them here to make sure they will have the right size next time the popup
+        // is open, regardless of whether the effective resolution has changed or not.
+        this.actor.set_height(-1);
+        this.actor.set_width(-1);
 
         if (!this.isOpen)
             return;

--- a/js/ui/popupMenu.js
+++ b/js/ui/popupMenu.js
@@ -1131,6 +1131,8 @@ const PopupMenu = new Lang.Class({
                                                overlay_scrollbars: true });
         this._boxWrapper.add_style_class_name('popup-menu-content');
         this._boxPointer.bin.set_child(this._boxWrapper);
+
+        this.box.add_style_class_name('popup-menu-content-box');
         this._boxWrapper.add_actor(this.box);
         this.actor.add_style_class_name('popup-menu');
 


### PR DESCRIPTION
This PR does three things:
  * Fixes a small bug I found around while looking at the code (Jasper's commit)
  * Makes sure that the popups get adjusted in size and show the relevant scrollbars when needed
  * Slightly adjust the CSS for popups so that horizontal rules are as close to the edge as vertical ones

[endlessm/eos-shell#6308]