### PR TITLE
appDisplay: Fix removal of icons from the grid

### DIFF
--- a/js/ui/appDisplay.js
+++ b/js/ui/appDisplay.js
@@ -291,7 +291,7 @@ const EndlessApplicationView = new Lang.Class({
         // So we update _allIcons to avoid this and make sure it
         // reflects what has been done "on the screen".
         for (let idx in removedList)
-           this._allIcons.splice(idx, 1);
+           this._allIcons.splice(removedList[idx], 1);
 
         this._grid.animateShuffling(movedList,
                                     removedList,


### PR DESCRIPTION
In the animateMovement function, we update the _allIcons variable but the
removal was not being done correctly, so we ended up removing always the
first icon of the list. This caused the first icon in the grid to
disappear/reappear when another icon was removed.

[endlessm/eos-shell#5849]