### PR TITLE
Add a way to update an app's desktop info

### DIFF
--- a/js/ui/appDisplay.js
+++ b/js/ui/appDisplay.js
@@ -534,6 +534,8 @@ const AllView = new Lang.Class({
         this._appSystem.connect('installed-changed', Lang.bind(this, function() {
             Main.queueDeferredWork(this._allAppsWorkId);
         }));
+        this._appSystem.connect('app-info-changed', Lang.bind(this, this._onAppInfoChanged));
+
         global.settings.connect('changed::app-folder-categories', Lang.bind(this, function() {
             Main.queueDeferredWork(this._allAppsWorkId);
         }));
@@ -588,6 +590,15 @@ const AllView = new Lang.Class({
                 time: ICON_ANIMATION_TIME,
                 delay: ICON_ANIMATION_DELAY
             });
+        }
+     },
+
+     _onAppInfoChanged: function(app_system, app) {
+        for (let icon of this._allIcons) {
+            if (icon.app && icon.app === app) {
+                icon.icon.reloadIcon();
+                break;
+            }
         }
      },
 

--- a/src/shell-app-system.h
+++ b/src/shell-app-system.h
@@ -32,6 +32,7 @@ struct _ShellAppSystemClass
 
   void (*installed_changed)(ShellAppSystem *appsys, gpointer user_data);
   void (*favorites_changed)(ShellAppSystem *appsys, gpointer user_data);
+  void (*app_info_changed)(ShellAppSystem *appsys, gpointer user_data);
 };
 
 GType           shell_app_system_get_type    (void) G_GNUC_CONST;


### PR DESCRIPTION
These changes add a DBus method to make the desktop aware that something about an application's desktop info has changed and, currently, uses that trigger to re-read an app's desktop info and update its icon in the desktop.
The use case is a weblink that can be added to the desktop before its favicon has been retrieved; thus, once the favicon has been downloaded and the desktop file changed, the app icon will be updated o the desktop with these changes.

[endlessm/eos-shell#4920]