### PR TITLE
Reimplement workspace monitor

### DIFF
--- a/js/ui/overview.js
+++ b/js/ui/overview.js
@@ -737,7 +737,7 @@ const Overview = new Lang.Class({
             return;
         }
 
-        if (Main.workspaceMonitor.visibleWindows === 0) {
+        if (!Main.workspaceMonitor.hasVisibleWindows) {
             this._viewSelector.blinkSearch();
             return;
         }
@@ -760,7 +760,7 @@ const Overview = new Lang.Class({
             return;
         }
 
-        if (Main.workspaceMonitor.visibleWindows === 0) {
+        if (!Main.workspaceMonitor.hasVisibleWindows) {
             this.showApps();
             return;
         }

--- a/js/ui/workspaceMonitor.js
+++ b/js/ui/workspaceMonitor.js
@@ -12,6 +12,7 @@ const WorkspaceMonitor = new Lang.Class({
     _init: function() {
         this._trackedApps = new Set();
         this._visibleApps = new Set();
+        this._startingApps = new Set();
 
         this._windowTracker = Shell.WindowTracker.get_default();
 
@@ -115,13 +116,25 @@ const WorkspaceMonitor = new Lang.Class({
         }
     },
 
+    _setAppStarting: function(app, starting) {
+        if (starting) {
+            this._startingApps.add(app);
+        } else {
+            this._startingApps.delete(app);
+        }
+    },
+
     _onAppStateChange: function(appSystem, app) {
-        if (app.get_state() == Shell.AppState.STOPPED) {
+        let app_state = app.get_state();
+
+        if (app_state == Shell.AppState.STOPPED) {
             this._setAppVisible(app, false);
             this._untrackApp(app);
         } else {
             this._trackApp(app);
         }
+
+        this._setAppStarting(app, app_state == Shell.AppState.STARTING);
     },
 
     _appHasVisibleWindows: function(app, excludeWindow) {
@@ -148,12 +161,7 @@ const WorkspaceMonitor = new Lang.Class({
     },
 
     _hasStartingApps: function() {
-        for (let app of this._trackedApps) {
-            if (app.get_state() == Shell.AppState.STARTING) {
-                return true;
-            }
-        }
-        return false;
+        return this._startingApps.size > 0;
     },
 
     get visibleApps() {

--- a/js/ui/workspaceMonitor.js
+++ b/js/ui/workspaceMonitor.js
@@ -125,16 +125,16 @@ const WorkspaceMonitor = new Lang.Class({
     },
 
     _onAppStateChange: function(appSystem, app) {
-        let app_state = app.get_state();
+        let state = app.get_state();
 
-        if (app_state == Shell.AppState.STOPPED) {
+        if (state == Shell.AppState.STOPPED) {
             this._setAppVisible(app, false);
             this._untrackApp(app);
         } else {
             this._trackApp(app);
         }
 
-        this._setAppStarting(app, app_state == Shell.AppState.STARTING);
+        this._setAppStarting(app, state == Shell.AppState.STARTING);
     },
 
     _appHasVisibleWindows: function(app, excludeWindow) {

--- a/js/ui/workspaceMonitor.js
+++ b/js/ui/workspaceMonitor.js
@@ -107,11 +107,11 @@ const WorkspaceMonitor = new Lang.Class({
     },
 
     _onAppStateChange: function(appSystem, app) {
-        if (app.get_state() == Shell.AppState.RUNNING) {
-            this._trackApp(app);
-        } else if (app.get_state() == Shell.AppState.STOPPED) {
+        if (app.get_state() == Shell.AppState.STOPPED) {
             this._setAppVisible(app, false);
             this._untrackApp(app);
+        } else {
+            this._trackApp(app);
         }
     },
 

--- a/js/ui/workspaceMonitor.js
+++ b/js/ui/workspaceMonitor.js
@@ -55,7 +55,10 @@ const WorkspaceMonitor = new Lang.Class({
         let app = this._windowTracker.get_window_app(actor.meta_window);
 
         if (this._appIsTracked(app)) {
-            this._setAppVisible(app, this._appHasVisibleWindows(app));
+            // We exclude the current window when checking for the visible ones because when
+            // this callback is called on 'destroy', the current window is counted as visible
+            this._setAppVisible(app, this._appHasVisibleWindows(app, actor.meta_window));
+
             if (this.visibleApps == 0) {
                 Main.layoutManager.prepareForOverview();
             }
@@ -121,13 +124,13 @@ const WorkspaceMonitor = new Lang.Class({
         }
     },
 
-    _appHasVisibleWindows: function(app) {
+    _appHasVisibleWindows: function(app, excludeWindow) {
         let windows = app.get_windows();
         for (let window of windows) {
             // We do not count transient windows because of an issue with Audacity
             // where a transient window was always being counted as visible even
             // though it was minimized
-            if (window.get_transient_for()) {
+            if (window.get_transient_for() || excludeWindow == window) {
                 continue;
             }
 

--- a/js/ui/workspaceMonitor.js
+++ b/js/ui/workspaceMonitor.js
@@ -12,7 +12,6 @@ const WorkspaceMonitor = new Lang.Class({
     _init: function() {
         this._trackedApps = new Set();
         this._visibleApps = new Set();
-        this._startingApps = new Set();
 
         this._windowTracker = Shell.WindowTracker.get_default();
 
@@ -91,7 +90,7 @@ const WorkspaceMonitor = new Lang.Class({
             // do not show the overview as it's likely that a window will be
             // shown. This avoids problems of windows being mapped while the
             // overview is being shown.
-            if (!this._hasStartingApps()) {
+            if (!this._appSystem.has_starting_apps()) {
                 Main.overview.showApps();
             }
         } else if (this._inFullscreen) {
@@ -116,14 +115,6 @@ const WorkspaceMonitor = new Lang.Class({
         }
     },
 
-    _setAppStarting: function(app, starting) {
-        if (starting) {
-            this._startingApps.add(app);
-        } else {
-            this._startingApps.delete(app);
-        }
-    },
-
     _onAppStateChange: function(appSystem, app) {
         let state = app.get_state();
 
@@ -133,8 +124,6 @@ const WorkspaceMonitor = new Lang.Class({
         } else {
             this._trackApp(app);
         }
-
-        this._setAppStarting(app, state == Shell.AppState.STARTING);
     },
 
     _appHasVisibleWindows: function(app, excludeWindow) {
@@ -158,10 +147,6 @@ const WorkspaceMonitor = new Lang.Class({
     _appIsTracked: function(app) {
         return this._trackedApps.has(app);
 
-    },
-
-    _hasStartingApps: function() {
-        return this._startingApps.size > 0;
     },
 
     get visibleApps() {

--- a/js/ui/workspaceMonitor.js
+++ b/js/ui/workspaceMonitor.js
@@ -10,17 +10,11 @@ const WorkspaceMonitor = new Lang.Class({
     Name: 'WorkspaceMonitor',
 
     _init: function() {
-        this._visibleApps = new Set();
-
-        this._windowTracker = Shell.WindowTracker.get_default();
-
         this._shellwm = global.window_manager;
         this._shellwm.connect('minimize', Lang.bind(this, this._windowDisappearing));
-        this._shellwm.connect('minimize-completed', Lang.bind(this, this._minimizeWindowCompleted));
-        this._shellwm.connect('unminimize', Lang.bind(this, this._unminimizeWindow));
-        this._shellwm.connect('map', Lang.bind(this, this._mapWindow));
+        this._shellwm.connect('minimize-completed', Lang.bind(this, this._updateOverview));
         this._shellwm.connect('destroy', Lang.bind(this, this._windowDisappearing));
-        this._shellwm.connect('destroy-completed', Lang.bind(this, this._destroyCompleted));
+        this._shellwm.connect('destroy-completed', Lang.bind(this, this._updateOverview));
 
         this._metaScreen = global.screen;
         this._metaScreen.connect('in-fullscreen-changed', Lang.bind(this, this._fullscreenChanged));
@@ -29,7 +23,6 @@ const WorkspaceMonitor = new Lang.Class({
         this._inFullscreen = primaryMonitor && primaryMonitor.inFullscreen;
 
         this._appSystem = Shell.AppSystem.get_default();
-        this._appSystem.connect('app-state-changed', Lang.bind(this, this._onAppStateChange));
     },
 
     _fullscreenChanged: function() {
@@ -42,41 +35,29 @@ const WorkspaceMonitor = new Lang.Class({
         }
     },
 
-    _mapWindow: function(shellwm, actor) {
-        let app = this._windowTracker.get_window_app(actor.meta_window);
-        this._setAppVisible(app, true);
-    },
-
     _windowDisappearing: function(shellwm, actor) {
-        let app = this._windowTracker.get_window_app(actor.meta_window);
+        function _isLastWindow(apps, win) {
+            if (apps.length == 0) {
+                return true;
+            }
 
-        // We exclude the current window when checking for the visible ones because when
-        // this callback is called on 'destroy', the current window is counted as visible
-        this._setAppVisible(app, this._appHasVisibleWindows(app, actor.meta_window));
+            if (apps.length > 1) {
+                return false;
+            }
 
-        if (this.visibleApps == 0) {
+            let windows = apps[0].get_windows();
+            return (windows.length == 1) && (windows[0] == win);
+        };
+
+        let visibleApps = this._getVisibleApps();
+        if (_isLastWindow(visibleApps, actor.meta_window)) {
             Main.layoutManager.prepareForOverview();
         }
     },
 
-    _minimizeWindowCompleted: function(shellwm, actor) {
-        let app = this._windowTracker.get_window_app(actor.meta_window);
-        this._setAppVisible(app, this._appHasVisibleWindows(app));
-
-        this._updateOverview();
-    },
-
-    _unminimizeWindow: function(shellwm, actor) {
-        let app = this._windowTracker.get_window_app(actor.meta_window);
-        this._setAppVisible(app, this._appHasVisibleWindows(app));
-    },
-
-    _destroyCompleted: function(shellwm, actor) {
-        this._updateOverview();
-    },
-
     _updateOverview: function() {
-        if (this.visibleApps == 0) {
+        let visibleApps = this._getVisibleApps();
+        if (visibleApps.length == 0) {
             // Even if no apps are visible, if there is an app starting up, we
             // do not show the overview as it's likely that a window will be
             // shown. This avoids problems of windows being mapped while the
@@ -90,51 +71,34 @@ const WorkspaceMonitor = new Lang.Class({
         }
     },
 
-    _setAppVisible: function(app, visible) {
-        if (visible) {
-            this._visibleApps.add(app);
-        } else {
-            this._visibleApps.delete(app);
-        }
-    },
+    _getVisibleApps: function() {
+        let runningApps = this._appSystem.get_running();
+        return runningApps.filter(function(app) {
+            let windows = app.get_windows();
+            for (let window of windows) {
+                // We do not count transient windows because of an issue with Audacity
+                // where a transient window was always being counted as visible even
+                // though it was minimized
+                if (window.get_transient_for()) {
+                    continue;
+                }
 
-    _onAppStateChange: function(appSystem, app) {
-        let state = app.get_state();
-
-        if (state == Shell.AppState.STOPPED) {
-            this._setAppVisible(app, false);
-        }
-    },
-
-    _appHasVisibleWindows: function(app, excludeWindow) {
-        let windows = app.get_windows();
-        for (let window of windows) {
-            // We do not count transient windows because of an issue with Audacity
-            // where a transient window was always being counted as visible even
-            // though it was minimized
-            if (window.get_transient_for() || excludeWindow == window) {
-                continue;
+                if (!window.minimized) {
+                    return true;
+                }
             }
 
-            if (!window.minimized) {
-                return true;
-            }
-        }
-
-        return false;
+            return false;
+        });
     },
 
-    get visibleApps() {
-        return this._visibleApps.size;
-    },
-
-    get visibleWindows() {
-        let visible = this.visibleApps;
-
+    get hasVisibleWindows() {
         // Count anything fullscreen as an extra window
         if (this._inFullscreen) {
-            visible += 1;
+            return true;
         }
-        return visible;
+
+        let visibleApps = this._getVisibleApps();
+        return visibleApps.length > 0;
     }
 });

--- a/js/ui/workspaceMonitor.js
+++ b/js/ui/workspaceMonitor.js
@@ -10,7 +10,6 @@ const WorkspaceMonitor = new Lang.Class({
     Name: 'WorkspaceMonitor',
 
     _init: function() {
-        this._trackedApps = new Set();
         this._visibleApps = new Set();
 
         this._windowTracker = Shell.WindowTracker.get_default();
@@ -45,23 +44,18 @@ const WorkspaceMonitor = new Lang.Class({
 
     _mapWindow: function(shellwm, actor) {
         let app = this._windowTracker.get_window_app(actor.meta_window);
-
-        if (this._appIsTracked(app)) {
-            this._setAppVisible(app, true);
-        }
+        this._setAppVisible(app, true);
     },
 
     _windowDisappearing: function(shellwm, actor) {
         let app = this._windowTracker.get_window_app(actor.meta_window);
 
-        if (this._appIsTracked(app)) {
-            // We exclude the current window when checking for the visible ones because when
-            // this callback is called on 'destroy', the current window is counted as visible
-            this._setAppVisible(app, this._appHasVisibleWindows(app, actor.meta_window));
+        // We exclude the current window when checking for the visible ones because when
+        // this callback is called on 'destroy', the current window is counted as visible
+        this._setAppVisible(app, this._appHasVisibleWindows(app, actor.meta_window));
 
-            if (this.visibleApps == 0) {
-                Main.layoutManager.prepareForOverview();
-            }
+        if (this.visibleApps == 0) {
+            Main.layoutManager.prepareForOverview();
         }
     },
 
@@ -74,10 +68,7 @@ const WorkspaceMonitor = new Lang.Class({
 
     _unminimizeWindow: function(shellwm, actor) {
         let app = this._windowTracker.get_window_app(actor.meta_window);
-
-        if (this._appIsTracked(app)) {
-            this._setAppVisible(app, this._appHasVisibleWindows(app));
-        }
+        this._setAppVisible(app, this._appHasVisibleWindows(app));
     },
 
     _destroyCompleted: function(shellwm, actor) {
@@ -99,14 +90,6 @@ const WorkspaceMonitor = new Lang.Class({
         }
     },
 
-    _trackApp: function(app) {
-        this._trackedApps.add(app);
-    },
-
-    _untrackApp: function(app) {
-        this._trackedApps.delete(app);
-    },
-
     _setAppVisible: function(app, visible) {
         if (visible) {
             this._visibleApps.add(app);
@@ -120,9 +103,6 @@ const WorkspaceMonitor = new Lang.Class({
 
         if (state == Shell.AppState.STOPPED) {
             this._setAppVisible(app, false);
-            this._untrackApp(app);
-        } else {
-            this._trackApp(app);
         }
     },
 
@@ -142,11 +122,6 @@ const WorkspaceMonitor = new Lang.Class({
         }
 
         return false;
-    },
-
-    _appIsTracked: function(app) {
-        return this._trackedApps.has(app);
-
     },
 
     get visibleApps() {

--- a/js/ui/workspaceMonitor.js
+++ b/js/ui/workspaceMonitor.js
@@ -83,7 +83,13 @@ const WorkspaceMonitor = new Lang.Class({
 
     _updateOverview: function() {
         if (this.visibleApps == 0) {
-            Main.overview.showApps();
+            // Even if no apps are visible, if there is an app starting up, we
+            // do not show the overview as it's likely that a window will be
+            // shown. This avoids problems of windows being mapped while the
+            // overview is being shown.
+            if (!this._hasStartingApps()) {
+                Main.overview.showApps();
+            }
         } else if (this._inFullscreen) {
             // Hide in fullscreen mode
             Main.overview.hide();
@@ -135,6 +141,16 @@ const WorkspaceMonitor = new Lang.Class({
 
     _appIsTracked: function(app) {
         return this._trackedApps.has(app);
+
+    },
+
+    _hasStartingApps: function() {
+        for (let app of this._trackedApps) {
+            if (app.get_state() == Shell.AppState.STARTING) {
+                return true;
+            }
+        }
+        return false;
     },
 
     get visibleApps() {

--- a/js/ui/workspaceMonitor.js
+++ b/js/ui/workspaceMonitor.js
@@ -10,246 +10,27 @@ const WorkspaceMonitor = new Lang.Class({
     Name: 'WorkspaceMonitor',
 
     _init: function() {
-        this._metaScreen = global.screen;
+        this._trackedApps = new Set();
+        this._visibleApps = new Set();
 
-        this._destroyedWindows = new Hash.Map();
-        this._minimizedWindows = new Hash.Map();
-        this._knownWindows = new Hash.Map();
+        this._windowTracker = Shell.WindowTracker.get_default();
 
         this._shellwm = global.window_manager;
-        this._shellwm.connect('minimize', Lang.bind(this, this._minimizeWindow));
+        this._shellwm.connect('minimize', Lang.bind(this, this._windowDisappearing));
         this._shellwm.connect('minimize-completed', Lang.bind(this, this._minimizeWindowCompleted));
         this._shellwm.connect('unminimize', Lang.bind(this, this._unminimizeWindow));
         this._shellwm.connect('map', Lang.bind(this, this._mapWindow));
-        this._shellwm.connect('destroy', Lang.bind(this, this._destroyWindow));
-        this._shellwm.connect('destroy-completed', Lang.bind(this, this._destroyWindowCompleted));
+        this._shellwm.connect('destroy', Lang.bind(this, this._windowDisappearing));
+        this._shellwm.connect('destroy-completed', Lang.bind(this, this._destroyCompleted));
 
-        this._metaScreen.connect('workspace-switched', Lang.bind(this, this._workspaceSwitched));
+        this._metaScreen = global.screen;
         this._metaScreen.connect('in-fullscreen-changed', Lang.bind(this, this._fullscreenChanged));
 
         let primaryMonitor = Main.layoutManager.primaryMonitor;
         this._inFullscreen = primaryMonitor && primaryMonitor.inFullscreen;
-        this._visibleWindows = 0;
 
-        this._trackWorkspace(this._metaScreen.get_active_workspace(), false);
-    },
-
-    _windowIsKnown: function(metaWindow) {
-        return this._knownWindows.has(metaWindow);
-    },
-
-    _addKnownWindow: function(metaWindow) {
-        this._knownWindows.set(metaWindow, true);
-    },
-
-    _removeKnownWindow: function(metaWindow) {
-        this._knownWindows.delete(metaWindow);
-    },
-
-    _windowIsMinimized: function(metaWindow) {
-        return this._minimizedWindows.has(metaWindow);
-    },
-
-    _addMinimizedWindow: function(metaWindow) {
-        this._minimizedWindows.set(metaWindow, true);
-    },
-
-    _removeMinimizedWindow: function(metaWindow) {
-        this._minimizedWindows.delete(metaWindow);
-    },
-
-    _windowIsDestroyed: function(metaWindow) {
-        return this._destroyedWindows.has(metaWindow);
-    },
-
-    _addDestroyedWindow: function(metaWindow) {
-        this._destroyedWindows.set(metaWindow, true);
-    },
-
-    _removeDestroyedWindow: function(metaWindow) {
-        this._destroyedWindows.delete(metaWindow);
-    },
-
-    _trackWorkspace: function(workspace, shouldUpdate) {
-        this._activeWorkspace = workspace;
-
-        // Setup to listen to the number of windows being changed
-        this._windowAddedId = this._activeWorkspace.connect('window-added', Lang.bind(this, this._windowAdded));
-        this._windowRemovedId = this._activeWorkspace.connect('window-removed', Lang.bind(this, this._windowRemoved));
-
-        // When we switch workspace or on startup we need to track what
-        // windows already exist on the system. Currently we only have
-        // one workspace so that isn't a problem.
-        let windows = this._activeWorkspace.list_windows();
-        for (let i = 0; i < windows.length; i++) {
-            let metaWindow = windows[i];
-
-            let added = this._realWindowAdded(metaWindow);
-            if (added == false) {
-                continue;
-            }
-
-            if (metaWindow.minimized) {
-                this._addMinimizedWindow(metaWindow);
-            } else {
-                this._realMapWindow(metaWindow);
-            }
-        }
-
-        if (shouldUpdate) {
-            this._updateOverview();
-        }
-    },
-
-    _untrackWorkspace: function() {
-        if (this._windowAddedId > 0) {
-            this._activeWorkspace.disconnect(this._windowAddedId);
-            this._windowAddedId = 0;
-        }
-
-        if (this._windowRemovedId > 0) {
-            this._activeWorkspace.disconnect(this._windowRemovedId);
-            this._windowRemovedId = 0;
-        }
-
-        this._activeWorkspace = null;
-
-        this._visibleWindows = 0;
-
-        this._minimizedWindows = new Hash.Map();
-        this._knownWindows = new Hash.Map();
-    },
-
-    _workspaceSwitched: function(from, to, direction) {
-        this._untrackWorkspace();
-        this._trackWorkspace(this._metaScreen.get_active_workspace(), true);
-    },
-
-    // The sequence of events is
-    // Window is mapped but not yet in system: _windowAdded
-    // Window is newly created: _windowAdded -> _mapWindow
-    // Window is minimized: _minimizeWindow
-    // Window is unminimized: _mapWindow
-    // Window is closed: _destroyWindow -> _windowRemoved
-    // Minimized window is closed: _windowRemoved
-    //
-    // This allows us to separate the work
-    // _windowAdded: Handles tracking of known windows
-    //               checks if a window is interesting and adds it to our list
-    //               of known windows. Also checks if it is minimized and if so
-    //               adds it to the list of minimized windows
-    // _windowRemoved: Is the opposite of _windowAdded
-    //
-    // _mapWindow: Handles tracking of visible windows
-    // _minimizeWindow:
-    // _destroyWindow: These are the opposite of _mapWindow for the 2 different
-    //                 ways a window can be taken off the screen: minimizing and
-    //                 closing
-    _realWindowAdded: function(metaWindow) {
-        // We special-case eos-speedwagon here, as we don't want to go
-        // back to the overview if the only window that was dismissed was the
-        // splash screen.
-        // See also shell_app_is_interesting_window() in src/shell-app.c, which
-        // was added for the same purpose.
-        // This code eventually should be changed to track applications instead
-        // of windows.
-        if (!Shell.WindowTracker.is_window_interesting(metaWindow) ||
-            metaWindow.get_role() == 'eos-speedwagon') {
-            return false;
-        }
-
-        this._addKnownWindow(metaWindow);
-        return true;
-    },
-
-    _windowAdded: function(metaWorkspace, metaWindow) {
-        this._realWindowAdded(metaWindow);
-    },
-
-    _windowRemoved: function(metaWorkspace, metaWindow) {
-        // Remove the window from our known windows
-        // Window will not be in knownWindows if it wasn't
-        // interesting to us.
-        if (!this._windowIsKnown(metaWindow)) {
-            return;
-        }
-
-        this._removeKnownWindow(metaWindow);
-    },
-
-    _windowGoingInvisible: function() {
-        // Check if we're minimizing the very last window
-        if (this.visibleWindows == 1) {
-            Main.layoutManager.prepareForOverview();
-        }
-    },
-
-    _windowGoingInvisibleCompleted: function() {
-        // Show the overview when the animation has ended.
-        this._visibleWindows -= 1;
-        this._updateOverview();
-    },
-
-    _destroyWindow: function(shellwm, actor) {
-        // _destroyWindow is not called for minimized windows
-        // so if the window is in _knownWindows then we handle it
-        if (!this._windowIsKnown(actor.meta_window)) {
-            return;
-        }
-
-        this._windowGoingInvisible();
-
-        // We'll show the overview when the destroy animation ends
-        this._addDestroyedWindow(actor.meta_window);
-    },
-
-    _destroyWindowCompleted: function(shellwm, actor) {
-        if (this._windowIsDestroyed(actor.meta_window)) {
-            this._windowGoingInvisibleCompleted();
-            this._removeDestroyedWindow(actor.meta_window);
-        }
-    },
-
-    _minimizeWindow: function(shellwm, actor) {
-        if (!this._windowIsKnown(actor.meta_window)) {
-            return;
-        }
-
-        this._windowGoingInvisible();
-
-        // We'll show the overview when the destroy animation ends
-        this._addMinimizedWindow(actor.meta_window);
-    },
-
-    _minimizeWindowCompleted: function(shellwm, actor) {
-        if (this._windowIsMinimized(actor.meta_window)) {
-            this._windowGoingInvisibleCompleted();
-            this._removeMinimizedWindow(actor.meta_window);
-        }
-    },
-
-    _realMapWindow: function(metaWindow) {
-        // If we don't know about it then we don't handle it
-        if (!this._windowIsKnown(metaWindow)) {
-            return;
-        }
-
-        // If the window was minimized remove it
-        if (this._windowIsMinimized(metaWindow)) {
-            this._removeMinimizedWindow(metaWindow);
-        }
-
-        this._visibleWindows += 1;
-
-        this._updateOverview();
-    },
-
-    _mapWindow: function(shellwm, actor) {
-        this._realMapWindow(actor.meta_window);
-    },
-
-    _unminimizeWindow: function(shellwm, actor) {
-        this._realMapWindow(actor.meta_window);
+        this._appSystem = Shell.AppSystem.get_default();
+        this._appSystem.connect('app-state-changed', Lang.bind(this, this._onAppStateChange));
     },
 
     _fullscreenChanged: function() {
@@ -262,15 +43,46 @@ const WorkspaceMonitor = new Lang.Class({
         }
     },
 
-    _updateOverview: function() {
-        // Check if the count has become messed up somehow
-        if (this._visibleWindows < 0) {
-            this._visibleWindows = 0;
+    _mapWindow: function(shellwm, actor) {
+        let app = this._windowTracker.get_window_app(actor.meta_window);
+
+        if (this._appIsTracked(app)) {
+            this._setAppVisible(app, true);
         }
+    },
 
+    _windowDisappearing: function(shellwm, actor) {
+        let app = this._windowTracker.get_window_app(actor.meta_window);
 
-        // Check the count from the getter to include fullscreen
-        if (this.visibleWindows == 0) {
+        if (this._appIsTracked(app)) {
+            this._setAppVisible(app, this._appHasVisibleWindows(app));
+            if (this.visibleApps == 0) {
+                Main.layoutManager.prepareForOverview();
+            }
+        }
+    },
+
+    _minimizeWindowCompleted: function(shellwm, actor) {
+        let app = this._windowTracker.get_window_app(actor.meta_window);
+        this._setAppVisible(app, this._appHasVisibleWindows(app));
+
+        this._updateOverview();
+    },
+
+    _unminimizeWindow: function(shellwm, actor) {
+        let app = this._windowTracker.get_window_app(actor.meta_window);
+
+        if (this._appIsTracked(app)) {
+            this._setAppVisible(app, this._appHasVisibleWindows(app));
+        }
+    },
+
+    _destroyCompleted: function(shellwm, actor) {
+        this._updateOverview();
+    },
+
+    _updateOverview: function() {
+        if (this.visibleApps == 0) {
             Main.overview.showApps();
         } else if (this._inFullscreen) {
             // Hide in fullscreen mode
@@ -278,8 +90,59 @@ const WorkspaceMonitor = new Lang.Class({
         }
     },
 
+    _trackApp: function(app) {
+        this._trackedApps.add(app);
+    },
+
+    _untrackApp: function(app) {
+        this._trackedApps.delete(app);
+    },
+
+    _setAppVisible: function(app, visible) {
+        if (visible) {
+            this._visibleApps.add(app);
+        } else {
+            this._visibleApps.delete(app);
+        }
+    },
+
+    _onAppStateChange: function(appSystem, app) {
+        if (app.get_state() == Shell.AppState.RUNNING) {
+            this._trackApp(app);
+        } else if (app.get_state() == Shell.AppState.STOPPED) {
+            this._setAppVisible(app, false);
+            this._untrackApp(app);
+        }
+    },
+
+    _appHasVisibleWindows: function(app) {
+        let windows = app.get_windows();
+        for (let window of windows) {
+            // We do not count transient windows because of an issue with Audacity
+            // where a transient window was always being counted as visible even
+            // though it was minimized
+            if (window.get_transient_for()) {
+                continue;
+            }
+
+            if (!window.minimized) {
+                return true;
+            }
+        }
+
+        return false;
+    },
+
+    _appIsTracked: function(app) {
+        return this._trackedApps.has(app);
+    },
+
+    get visibleApps() {
+        return this._visibleApps.size;
+    },
+
     get visibleWindows() {
-        let visible = this._visibleWindows;
+        let visible = this.visibleApps;
 
         // Count anything fullscreen as an extra window
         if (this._inFullscreen) {

--- a/src/shell-app-system.c
+++ b/src/shell-app-system.c
@@ -487,3 +487,9 @@ shell_app_system_get_running (ShellAppSystem *self)
 
   return ret;
 }
+
+gboolean
+shell_app_system_has_starting_apps (ShellAppSystem *self)
+{
+  return g_hash_table_size (self->priv->starting_apps) > 0;
+}

--- a/src/shell-app-system.h
+++ b/src/shell-app-system.h
@@ -49,5 +49,6 @@ ShellApp       *shell_app_system_lookup_desktop_wmclass       (ShellAppSystem *s
                                                                const char     *wmclass);
 
 GSList         *shell_app_system_get_running               (ShellAppSystem  *self);
+gboolean        shell_app_system_has_starting_apps         (ShellAppSystem  *self);
 
 #endif /* __SHELL_APP_SYSTEM_H__ */

--- a/src/shell-app.c
+++ b/src/shell-app.c
@@ -935,12 +935,14 @@ shell_app_sync_running_state (ShellApp *app)
 {
   g_return_if_fail (app->running_state != NULL);
 
-  if (app->state != SHELL_APP_STATE_STARTING)
+  if (app->running_state->interesting_windows == 0)
     {
-      if (app->running_state->interesting_windows == 0)
+      if (app->state != SHELL_APP_STATE_STARTING)
         shell_app_state_transition (app, SHELL_APP_STATE_STOPPED);
-      else
-        shell_app_state_transition (app, SHELL_APP_STATE_RUNNING);
+    }
+  else
+    {
+      shell_app_state_transition (app, SHELL_APP_STATE_RUNNING);
     }
 }
 
@@ -1291,6 +1293,9 @@ shell_app_launch (ShellApp     *app,
       meta_window_activate (window, timestamp);
       return TRUE;
     }
+
+  if (app->state == SHELL_APP_STATE_STOPPED)
+    shell_app_state_transition (app, SHELL_APP_STATE_STARTING);
 
   global = shell_global_get ();
   screen = shell_global_get_screen (global);


### PR DESCRIPTION
These changes reimplement the workspace monitor and base the logic on apps' events instead of windows's events.

[endlessm/eos-shell#4190]