### PR TITLE
Reimplement the workspace monitor based on apps

### DIFF
--- a/js/ui/workspaceMonitor.js
+++ b/js/ui/workspaceMonitor.js
@@ -10,246 +10,25 @@ const WorkspaceMonitor = new Lang.Class({
     Name: 'WorkspaceMonitor',
 
     _init: function() {
-        this._metaScreen = global.screen;
+        this._trackedApps = new Hash.Map();
+        this._visibleApps = new Set();
 
-        this._destroyedWindows = new Hash.Map();
-        this._minimizedWindows = new Hash.Map();
-        this._knownWindows = new Hash.Map();
+        this._windowTracker = Shell.WindowTracker.get_default();
 
         this._shellwm = global.window_manager;
         this._shellwm.connect('minimize', Lang.bind(this, this._minimizeWindow));
         this._shellwm.connect('minimize-completed', Lang.bind(this, this._minimizeWindowCompleted));
         this._shellwm.connect('unminimize', Lang.bind(this, this._unminimizeWindow));
         this._shellwm.connect('map', Lang.bind(this, this._mapWindow));
-        this._shellwm.connect('destroy', Lang.bind(this, this._destroyWindow));
-        this._shellwm.connect('destroy-completed', Lang.bind(this, this._destroyWindowCompleted));
 
-        this._metaScreen.connect('workspace-switched', Lang.bind(this, this._workspaceSwitched));
+        this._metaScreen = global.screen;
         this._metaScreen.connect('in-fullscreen-changed', Lang.bind(this, this._fullscreenChanged));
 
         let primaryMonitor = Main.layoutManager.primaryMonitor;
         this._inFullscreen = primaryMonitor && primaryMonitor.inFullscreen;
-        this._visibleWindows = 0;
 
-        this._trackWorkspace(this._metaScreen.get_active_workspace(), false);
-    },
-
-    _windowIsKnown: function(metaWindow) {
-        return this._knownWindows.has(metaWindow);
-    },
-
-    _addKnownWindow: function(metaWindow) {
-        this._knownWindows.set(metaWindow, true);
-    },
-
-    _removeKnownWindow: function(metaWindow) {
-        this._knownWindows.delete(metaWindow);
-    },
-
-    _windowIsMinimized: function(metaWindow) {
-        return this._minimizedWindows.has(metaWindow);
-    },
-
-    _addMinimizedWindow: function(metaWindow) {
-        this._minimizedWindows.set(metaWindow, true);
-    },
-
-    _removeMinimizedWindow: function(metaWindow) {
-        this._minimizedWindows.delete(metaWindow);
-    },
-
-    _windowIsDestroyed: function(metaWindow) {
-        return this._destroyedWindows.has(metaWindow);
-    },
-
-    _addDestroyedWindow: function(metaWindow) {
-        this._destroyedWindows.set(metaWindow, true);
-    },
-
-    _removeDestroyedWindow: function(metaWindow) {
-        this._destroyedWindows.delete(metaWindow);
-    },
-
-    _trackWorkspace: function(workspace, shouldUpdate) {
-        this._activeWorkspace = workspace;
-
-        // Setup to listen to the number of windows being changed
-        this._windowAddedId = this._activeWorkspace.connect('window-added', Lang.bind(this, this._windowAdded));
-        this._windowRemovedId = this._activeWorkspace.connect('window-removed', Lang.bind(this, this._windowRemoved));
-
-        // When we switch workspace or on startup we need to track what
-        // windows already exist on the system. Currently we only have
-        // one workspace so that isn't a problem.
-        let windows = this._activeWorkspace.list_windows();
-        for (let i = 0; i < windows.length; i++) {
-            let metaWindow = windows[i];
-
-            let added = this._realWindowAdded(metaWindow);
-            if (added == false) {
-                continue;
-            }
-
-            if (metaWindow.minimized) {
-                this._addMinimizedWindow(metaWindow);
-            } else {
-                this._realMapWindow(metaWindow);
-            }
-        }
-
-        if (shouldUpdate) {
-            this._updateOverview();
-        }
-    },
-
-    _untrackWorkspace: function() {
-        if (this._windowAddedId > 0) {
-            this._activeWorkspace.disconnect(this._windowAddedId);
-            this._windowAddedId = 0;
-        }
-
-        if (this._windowRemovedId > 0) {
-            this._activeWorkspace.disconnect(this._windowRemovedId);
-            this._windowRemovedId = 0;
-        }
-
-        this._activeWorkspace = null;
-
-        this._visibleWindows = 0;
-
-        this._minimizedWindows = new Hash.Map();
-        this._knownWindows = new Hash.Map();
-    },
-
-    _workspaceSwitched: function(from, to, direction) {
-        this._untrackWorkspace();
-        this._trackWorkspace(this._metaScreen.get_active_workspace(), true);
-    },
-
-    // The sequence of events is
-    // Window is mapped but not yet in system: _windowAdded
-    // Window is newly created: _windowAdded -> _mapWindow
-    // Window is minimized: _minimizeWindow
-    // Window is unminimized: _mapWindow
-    // Window is closed: _destroyWindow -> _windowRemoved
-    // Minimized window is closed: _windowRemoved
-    //
-    // This allows us to separate the work
-    // _windowAdded: Handles tracking of known windows
-    //               checks if a window is interesting and adds it to our list
-    //               of known windows. Also checks if it is minimized and if so
-    //               adds it to the list of minimized windows
-    // _windowRemoved: Is the opposite of _windowAdded
-    //
-    // _mapWindow: Handles tracking of visible windows
-    // _minimizeWindow:
-    // _destroyWindow: These are the opposite of _mapWindow for the 2 different
-    //                 ways a window can be taken off the screen: minimizing and
-    //                 closing
-    _realWindowAdded: function(metaWindow) {
-        // We special-case eos-speedwagon here, as we don't want to go
-        // back to the overview if the only window that was dismissed was the
-        // splash screen.
-        // See also shell_app_is_interesting_window() in src/shell-app.c, which
-        // was added for the same purpose.
-        // This code eventually should be changed to track applications instead
-        // of windows.
-        if (!Shell.WindowTracker.is_window_interesting(metaWindow) ||
-            metaWindow.get_role() == 'eos-speedwagon') {
-            return false;
-        }
-
-        this._addKnownWindow(metaWindow);
-        return true;
-    },
-
-    _windowAdded: function(metaWorkspace, metaWindow) {
-        this._realWindowAdded(metaWindow);
-    },
-
-    _windowRemoved: function(metaWorkspace, metaWindow) {
-        // Remove the window from our known windows
-        // Window will not be in knownWindows if it wasn't
-        // interesting to us.
-        if (!this._windowIsKnown(metaWindow)) {
-            return;
-        }
-
-        this._removeKnownWindow(metaWindow);
-    },
-
-    _windowGoingInvisible: function() {
-        // Check if we're minimizing the very last window
-        if (this.visibleWindows == 1) {
-            Main.layoutManager.prepareForOverview();
-        }
-    },
-
-    _windowGoingInvisibleCompleted: function() {
-        // Show the overview when the animation has ended.
-        this._visibleWindows -= 1;
-        this._updateOverview();
-    },
-
-    _destroyWindow: function(shellwm, actor) {
-        // _destroyWindow is not called for minimized windows
-        // so if the window is in _knownWindows then we handle it
-        if (!this._windowIsKnown(actor.meta_window)) {
-            return;
-        }
-
-        this._windowGoingInvisible();
-
-        // We'll show the overview when the destroy animation ends
-        this._addDestroyedWindow(actor.meta_window);
-    },
-
-    _destroyWindowCompleted: function(shellwm, actor) {
-        if (this._windowIsDestroyed(actor.meta_window)) {
-            this._windowGoingInvisibleCompleted();
-            this._removeDestroyedWindow(actor.meta_window);
-        }
-    },
-
-    _minimizeWindow: function(shellwm, actor) {
-        if (!this._windowIsKnown(actor.meta_window)) {
-            return;
-        }
-
-        this._windowGoingInvisible();
-
-        // We'll show the overview when the destroy animation ends
-        this._addMinimizedWindow(actor.meta_window);
-    },
-
-    _minimizeWindowCompleted: function(shellwm, actor) {
-        if (this._windowIsMinimized(actor.meta_window)) {
-            this._windowGoingInvisibleCompleted();
-            this._removeMinimizedWindow(actor.meta_window);
-        }
-    },
-
-    _realMapWindow: function(metaWindow) {
-        // If we don't know about it then we don't handle it
-        if (!this._windowIsKnown(metaWindow)) {
-            return;
-        }
-
-        // If the window was minimized remove it
-        if (this._windowIsMinimized(metaWindow)) {
-            this._removeMinimizedWindow(metaWindow);
-        }
-
-        this._visibleWindows += 1;
-
-        this._updateOverview();
-    },
-
-    _mapWindow: function(shellwm, actor) {
-        this._realMapWindow(actor.meta_window);
-    },
-
-    _unminimizeWindow: function(shellwm, actor) {
-        this._realMapWindow(actor.meta_window);
+        this._appSystem = Shell.AppSystem.get_default();
+        this._appSystem.connect('app-state-changed', Lang.bind(this, this._onAppStateChange));
     },
 
     _fullscreenChanged: function() {
@@ -262,15 +41,46 @@ const WorkspaceMonitor = new Lang.Class({
         }
     },
 
-    _updateOverview: function() {
-        // Check if the count has become messed up somehow
-        if (this._visibleWindows < 0) {
-            this._visibleWindows = 0;
+    _mapWindow: function(shellwm, actor) {
+        let app = this._windowTracker.get_window_app(actor.meta_window);
+
+        if (app in this._trackedApps) {
+            this._setAppVisible(app, this._appHasVisibleWindows(app));
+            this._updateOverview();
+        }
+    },
+
+    _minimizeWindow: function(shellwm, actor) {
+        let app = this._windowTracker.get_window_app(actor.meta_window);
+
+        if (app in this._trackedApps) {
+            this._setAppVisible(app, this._appHasVisibleWindows(app));
+            if (this._visibleApps.size == 0) {
+                Main.layoutManager.prepareForOverview();
+            }
+        }
+    },
+
+    _minimizeWindowCompleted: function(shellwm, actor) {
+        let app = this._windowTracker.get_window_app(actor.meta_window);
+
+        if (app in this._trackedApps) {
+            this._setAppVisible(app, this._appHasVisibleWindows(app));
         }
 
+        this._updateOverview();
+    },
 
-        // Check the count from the getter to include fullscreen
-        if (this.visibleWindows == 0) {
+    _unminimizeWindow: function(shellwm, actor) {
+        let app = this._windowTracker.get_window_app(actor.meta_window);
+
+        if (app in this._trackedApps ) {
+            this._setAppVisible(app, this._appHasVisibleWindows(app));
+        }
+    },
+
+    _updateOverview: function() {
+        if (this._visibleApps.size == 0) {
             Main.overview.showApps();
         } else if (this._inFullscreen) {
             // Hide in fullscreen mode
@@ -278,8 +88,66 @@ const WorkspaceMonitor = new Lang.Class({
         }
     },
 
+    _trackApp: function(app) {
+        if (!(app in this._trackedApps))
+            this._trackedApps[app] = app.connect('windows-changed', Lang.bind(this, this._onAppWindowsChanged));
+    },
+
+    _untrackApp: function(app) {
+        if (app in this._trackedApps) {
+            app.disconnect(this._trackedApps[app]);
+            delete this._trackedApps[app];
+        }
+    },
+
+    _setAppVisible: function(app, visible) {
+        if (visible)
+            this._visibleApps.add(app);
+        else
+            this._visibleApps.delete(app);
+    },
+
+    _onAppStateChange: function(appSystem, app) {
+        if (app.get_state() == Shell.AppState.RUNNING) {
+            this._trackApp(app);
+        }
+    },
+
+    _onAppWindowsChanged: function(app) {
+        this._setAppVisible(app, this._appHasVisibleWindows(app));
+
+        // We need to track the stopped state here (instead of in _onAppStateChange),
+        // and independently from setting an app visible, because there are apps
+        // that go into "running" -> "stopped" -> "running" states because of the
+        // way they show their windows. This is the case of the Maps (marble) app.
+        if (app.get_state() == Shell.AppState.STOPPED) {
+            let has_visible_windows = this._appHasVisibleWindows(app);
+            this._setAppVisible(app, has_visible_windows);
+            if (!has_visible_windows)
+                this._untrackApp(app);
+        }
+
+        this._updateOverview();
+    },
+
+    _appHasVisibleWindows: function(app) {
+        let windows = app.get_windows();
+        for (let window of windows) {
+            // We do not count transient windows because of an issue with Audacity
+            // where a transient window was always being counted as visible even
+            // though it was minimized
+            if (window.get_transient_for())
+                continue;
+
+            if (!window.minimized)
+                return true;
+        }
+
+        return false;
+    },
+
     get visibleWindows() {
-        let visible = this._visibleWindows;
+        let visible = this._visibleApps.size;
 
         // Count anything fullscreen as an extra window
         if (this._inFullscreen) {


### PR DESCRIPTION
These changes replace the way the workspace monitor works by tracking
visible windows per application instead of per window. Besides
simplifying the code, it also fixes some issues related to launching
apps, e.g. launching Maps (marble) was sometimes opening the app with
the windows minimized.

[endlessm/eos-shell#4190]