### PR TITLE
issue/5950

### DIFF
--- a/js/ui/layout.js
+++ b/js/ui/layout.js
@@ -27,6 +27,9 @@ const DEFAULT_BACKGROUND_COLOR = Clutter.Color.from_pixel(0x2e3436ff);
 // Gsettings key to enable the message tray pressure barrier.
 const ENABLE_MESSAGE_TRAY_BARRIER_KEY = 'enable-message-tray-barrier'
 
+// GSettings key to track the text scaling factor
+const KEY_TEXT_SCALING_FACTOR = 'text-scaling-factor';
+
 // The message tray takes this much pressure
 // in the pressure barrier at once to release it.
 const MESSAGE_TRAY_PRESSURE_THRESHOLD = 250; // pixels
@@ -421,6 +424,22 @@ const LayoutManager = new Lang.Class({
                                 Lang.bind(this, this._updateHotCorners));
 
         this._monitorsChanged();
+
+        /*
+         * When we're not in the Overview and the text scaling factor changes, the
+         * Overview icons don't update to match the new font size. To fix that, and
+         * some random font rendering issues in apps, toggle the Overview.
+         */
+        Main.interfaceSettings.connect('changed::' + KEY_TEXT_SCALING_FACTOR, Lang.bind(this, function() {
+            if (!this._inOverview) {
+                Main.layoutManager.showOverview();
+
+                GLib.idle_add(GLib.PRIORITY_DEFAULT, Lang.bind(this, function() {
+                                  this.hideOverview();
+                                  return false;
+                              }));
+            }
+        }));
     },
 
     // This is called by Main after everything else is constructed

--- a/js/ui/main.js
+++ b/js/ui/main.js
@@ -42,6 +42,7 @@ const Util = imports.misc.util;
 
 const OVERRIDES_SCHEMA = 'org.gnome.shell.overrides';
 const DEFAULT_BACKGROUND_COLOR = Clutter.Color.from_pixel(0x2e3436ff);
+const DESKTOP_INTERFACE_SCHEMA = 'org.gnome.desktop.interface';
 const LOW_RESOLUTION_WIDTH = 800;
 const LOW_RESOLUTION_HEIGHT = 600;
 
@@ -74,6 +75,7 @@ let layoutManager = null;
 let workspaceMonitor = null;
 let desktopAppClient = null;
 let lowResolutionDisplay = false;
+let interfaceSettings = null;
 let _startDate;
 let _defaultCssStylesheet = null;
 let _cssStylesheet = null;
@@ -141,6 +143,9 @@ function _initializeUI() {
     resource._register();
 
     _loadDefaultStylesheet();
+
+    // Load a GSetting to track changes on text-scaling-factor
+    interfaceSettings = new Gio.Settings({ schema: DESKTOP_INTERFACE_SCHEMA });
 
     // Setup the stage hierarchy early
     layoutManager = new Layout.LayoutManager();


### PR DESCRIPTION
The Shell's Overview sets up a clone of the app grid to apply
the Saturation effect when minimized. The problem with this
approach, however, is that we end up never updating the real
child when something changes while we're not in Overview.

This wouldn't be a problem, but there may be unmaximized windows
that exposes part of the Overview - in this case, this issue
is pretty noticeable.

Fix that by toggling the Overview on and off.

[endlessm/eos-shell#5950]