### PR TITLE
loginDialog: Fix gjs warning

### DIFF
--- a/js/gdm/loginDialog.js
+++ b/js/gdm/loginDialog.js
@@ -1179,6 +1179,7 @@ const LoginDialog = new Lang.Class({
                              this._promptEntry.reactive = false;
                              return this._beginVerificationForUser(userName);
                          }
+                         return undefined;
                      }];
 
         let batch = new Batch.ConsecutiveBatch(this, tasks);


### PR DESCRIPTION
JS WARNING: [resource:///org/gnome/shell/gdm/loginDialog.js 1174]:
anonymous function does not always return a value

No behavior change, just silencing the warning.

[endlessm/eos-shell#6352]