### PR TITLE
ShellApp: don't transition to STARTING state from launch

### DIFF
--- a/src/shell-app.c
+++ b/src/shell-app.c
@@ -1066,9 +1066,15 @@ shell_app_ensure_busy_watch (ShellApp *app)
 }
 
 static gboolean
+shell_app_is_speedwagon_window (MetaWindow *window)
+{
+  return g_strcmp0 (meta_window_get_role (window), "eos-speedwagon") == 0;
+}
+
+static gboolean
 shell_app_is_interesting_window (MetaWindow *window)
 {
-  if (g_strcmp0 (meta_window_get_role (window), "eos-speedwagon") == 0)
+  if (shell_app_is_speedwagon_window (window))
     return FALSE;
 
   return shell_window_tracker_is_window_interesting (window);


### PR DESCRIPTION
Instead, track the number of speedwagon windows, in addition to the
regular logic, to decide if we should move to the STARTING state.
At the same time, make it possible to transition from STARTING to
STOPPED following the same logic.

[endlessm/eos-shell#6018]