### PR TITLE
Prevent the speedwagon from showing in the icon menu

### DIFF
--- a/js/ui/appActivation.js
+++ b/js/ui/appActivation.js
@@ -326,7 +326,7 @@ const DesktopAppClient = new Lang.Class({
 
     _windowCreated: function(metaDisplay, metaWindow) {
         // Ignore splash screens, which will already be maximized.
-        if (metaWindow.get_role() == 'eos-speedwagon') {
+        if (Shell.WindowTracker.is_speedwagon_window(metaWindow)) {
             return;
         }
 

--- a/js/ui/appIconBar.js
+++ b/js/ui/appIconBar.js
@@ -441,7 +441,7 @@ const AppIconButton = new Lang.Class({
         if (windows.length == 0) {
             let activationContext = new AppActivation.AppActivationContext(this._app);
             activationContext.activate();
-        } else if (numRealWindows == 1) {
+        } else if (numRealWindows == 1 && !hasSpeedwagon) {
             let win = windows[0];
             if (win.has_focus() && !Main.overview.visible && !hasOtherMenu) {
                 // The overview is not visible, and this is the

--- a/js/ui/appIconBar.js
+++ b/js/ui/appIconBar.js
@@ -172,7 +172,8 @@ const AppIconMenu = new Lang.Class({
         let otherWindows = [];
 
         windows.forEach(function(w) {
-            if (!Shell.WindowTracker.is_window_interesting(w)) {
+            if (!Shell.WindowTracker.is_window_interesting(w) ||
+                Shell.WindowTracker.is_speedwagon_window(w)) {
                 return;
             }
 

--- a/js/ui/appIconBar.js
+++ b/js/ui/appIconBar.js
@@ -366,10 +366,16 @@ const AppIconButton = new Lang.Class({
 
     _getInterestingWindows: function() {
         let windows = this._app.get_windows();
+        let hasSpeedwagon = false;
         windows = windows.filter(function(metaWindow) {
+            hasSpeedwagon = hasSpeedwagon || Shell.WindowTracker.is_speedwagon_window(metaWindow);
             return Shell.WindowTracker.is_window_interesting(metaWindow);
         });
-        return windows;
+        return [windows, hasSpeedwagon];
+    },
+
+    _getNumRealWindows: function(windows, hasSpeedwagon) {
+        return windows.length - (hasSpeedwagon ? 1 : 0);
     },
 
     _handleButtonPressEvent: function(actor, event) {
@@ -381,8 +387,10 @@ const AppIconButton = new Lang.Class({
             this._hideHoverState();
             this.emit('app-icon-pressed');
 
-            let windows = this._getInterestingWindows();
-            if (windows.length > 1) {
+            let [windows, hasSpeedwagon] = this._getInterestingWindows();
+            let numRealWindows = this._getNumRealWindows(windows, hasSpeedwagon);
+
+            if (numRealWindows > 1) {
                 let hasOtherMenu = this._hasOtherMenuOpen();
                 let animation = BoxPointer.PopupAnimation.FULL;
                 if (hasOtherMenu) {
@@ -425,12 +433,14 @@ const AppIconButton = new Lang.Class({
         this._closeOtherMenus(BoxPointer.PopupAnimation.FULL);
         this._animateBounce();
 
-        let windows = this._getInterestingWindows();
+        let [windows, hasSpeedwagon] = this._getInterestingWindows();
+        let numRealWindows = this._getNumRealWindows(windows, hasSpeedwagon);
+
         // The multiple windows case is handled in button-press-event
         if (windows.length == 0) {
             let activationContext = new AppActivation.AppActivationContext(this._app);
             activationContext.activate();
-        } else if (windows.length == 1) {
+        } else if (numRealWindows == 1) {
             let win = windows[0];
             if (win.has_focus() && !Main.overview.visible && !hasOtherMenu) {
                 // The overview is not visible, and this is the
@@ -446,7 +456,7 @@ const AppIconButton = new Lang.Class({
     activateFirstWindow: function() {
         this._animateBounce();
         this._closeOtherMenus(BoxPointer.PopupAnimation.FULL);
-        let windows = this._getInterestingWindows();
+        let windows = this._getInterestingWindows()[0];
         if (windows.length > 0) {
             Main.activateWindow(windows[0]);
         } else {

--- a/js/ui/windowAttentionHandler.js
+++ b/js/ui/windowAttentionHandler.js
@@ -33,7 +33,7 @@ const WindowAttentionHandler = new Lang.Class({
             return;
 
 	let focusWindow = global.display.focus_window;
-	if (focusWindow && focusWindow.get_role() == 'eos-speedwagon')
+	if (focusWindow && Shell.WindowTracker.is_speedwagon_window(focusWindow))
 	    return;
 
         let app = this._tracker.get_window_app(window);

--- a/js/ui/windowManager.js
+++ b/js/ui/windowManager.js
@@ -967,7 +967,7 @@ const WindowManager = new Lang.Class({
             actor._windowType = type;
         }));
 
-        let isSplashWindow = (window.get_role() == 'eos-speedwagon');
+        let isSplashWindow = Shell.WindowTracker.is_speedwagon_window(window);
 
         if (!isSplashWindow) {
             // If we have an active splash window for the app, don't animate it.
@@ -975,7 +975,7 @@ const WindowManager = new Lang.Class({
             let tracker = Shell.WindowTracker.get_default();
             let app = tracker.get_window_app(window);
             let hasSplashWindow = (app && app.get_windows().some(function(window) {
-                return (window.get_role() == 'eos-speedwagon')
+                return Shell.WindowTracker.is_speedwagon_window(window);
             }));
             if (hasSplashWindow) {
                 shellwm.completed_map(actor);

--- a/src/shell-app.c
+++ b/src/shell-app.c
@@ -1072,15 +1072,9 @@ shell_app_ensure_busy_watch (ShellApp *app)
 }
 
 static gboolean
-shell_app_is_speedwagon_window (MetaWindow *window)
-{
-  return g_strcmp0 (meta_window_get_role (window), "eos-speedwagon") == 0;
-}
-
-static gboolean
 shell_app_is_interesting_window (MetaWindow *window)
 {
-  if (shell_app_is_speedwagon_window (window))
+  if (shell_window_tracker_is_speedwagon_window (window))
     return FALSE;
 
   return shell_window_tracker_is_window_interesting (window);
@@ -1109,7 +1103,7 @@ _shell_app_add_window (ShellApp        *app,
 
   if (shell_app_is_interesting_window (window))
     app->running_state->interesting_windows++;
-  else if (shell_app_is_speedwagon_window (window))
+  else if (shell_window_tracker_is_speedwagon_window (window))
     app->running_state->speedwagon_windows++;
 
   shell_app_sync_running_state (app);
@@ -1136,7 +1130,7 @@ _shell_app_remove_window (ShellApp   *app,
 
   if (shell_app_is_interesting_window (window))
     app->running_state->interesting_windows--;
-  else if (shell_app_is_speedwagon_window (window))
+  else if (shell_window_tracker_is_speedwagon_window (window))
     app->running_state->speedwagon_windows--;
 
   if (app->running_state->windows == NULL)

--- a/src/shell-window-tracker.c
+++ b/src/shell-window-tracker.c
@@ -40,6 +40,7 @@
  */
 
 #define SIDE_COMPONENT_ROLE "eos-side-component"
+#define SPEEDWAGON_ROLE "eos-speedwagon"
 
 struct _ShellWindowTracker
 {
@@ -161,6 +162,18 @@ shell_window_tracker_is_window_interesting (MetaWindow *window)
     return FALSE;
 
   return TRUE;
+}
+
+/**
+ * shell_window_tracker_is_speedwagon_window:
+ *
+ * A speedwagon window is shown while an application is being launched.
+ *
+ * Returns: %TRUE if a window is a speedwagon
+ */
+gboolean shell_window_tracker_is_speedwagon_window (MetaWindow *window)
+{
+  return g_strcmp0 (meta_window_get_role (window), SPEEDWAGON_ROLE) == 0;
 }
 
 /*

--- a/src/shell-window-tracker.h
+++ b/src/shell-window-tracker.h
@@ -37,6 +37,8 @@ ShellApp *shell_window_tracker_get_app_from_pid (ShellWindowTracker *tracker, in
 
 gboolean shell_window_tracker_is_window_interesting (MetaWindow *window);
 
+gboolean shell_window_tracker_is_speedwagon_window (MetaWindow *window);
+
 const char *_shell_window_tracker_get_app_context (ShellWindowTracker *tracker, ShellApp *app);
 
 GSList *shell_window_tracker_get_startup_sequences (ShellWindowTracker *tracker);


### PR DESCRIPTION
The last commit in the PR is not so much related to the issue that it tries to solve but just replaces the check for the speedwagon by the function added in the window-tracker which makes the code a lot cleaner.

T6408