### PR TITLE
screenShield: Do not reset login screen in greeter mode

### DIFF
--- a/js/ui/screenShield.js
+++ b/js/ui/screenShield.js
@@ -408,7 +408,8 @@ const ScreenShield = new Lang.Class({
                 Main.sessionMode.pushMode('unlock-dialog');
         }
 
-        this._resetLockScreen(animate);
+        if (!this._isGreeter)
+            this._resetLockScreen(animate);
 
         // We used to set isActive and emit active-changed here,
         // but now we do that from lockScreenShown, which means


### PR DESCRIPTION
There's no value in doing this. Upstream doesn't do it. It breaks
password reset via email, except in the case the user manually moves
the mouse or presses a key every five minutes to keep the screen from
blanking.
https://phabricator.endlessm.com/T10864