### PR TITLE
workspace: Do not crash when launching eos-tutorial

### DIFF
--- a/js/ui/workspace.js
+++ b/js/ui/workspace.js
@@ -1022,6 +1022,9 @@ const Workspace = new Lang.Class({
     positionWindows: function(flags) {
         this._positionWindowsFlags |= flags;
 
+        if (!this.actor.mapped)
+            return;
+
         if (this._positionWindowsId > 0)
             return;
 


### PR DESCRIPTION
We cannot compute window positions before the Workspace actor has been
mapped.

https://phabricator.endlessm.com/T3881

(Same as https://github.com/endlessm/eos-desktop/pull/131)