### PR TITLE
NetworkAgent: Fix double-unref in get_secrets_keyring_cb()

### DIFF
--- a/src/shell-network-agent.c
+++ b/src/shell-network-agent.c
@@ -332,8 +332,6 @@ get_secrets_keyring_cb (GObject            *source,
               else
                 n_found += 1;
 
-              g_hash_table_unref (attributes);
-              secret_value_unref (secret);
               break;
             }
         }


### PR DESCRIPTION
In get_secrets_keyring_cb, we own a ref on the 'attributes' hash table
from secret_item_get_attributes), and a ref on the 'secret' object (from
secret_item_get_secret(), but in the SHELL_KEYRING_SK_TAG case, we unref
these once before breaking out of the loop, and the second time after
breaking out of the loop.

https://phabricator.endlessm.com/T10828