### PR TITLE
WindowManager: Prevent error when sliding out a side component

### DIFF
--- a/js/ui/sideComponent.js
+++ b/js/ui/sideComponent.js
@@ -118,6 +118,12 @@ const SideComponent = new Lang.Class({
     },
 
     _onPropertiesChanged: function(proxy, changedProps, invalidatedProps) {
+        // check if the side component connection died and reset 'visible'
+        if (!this.proxy.g_name_owner) {
+            this._visible = false;
+            return;
+        }
+
         let propsDict = changedProps.deep_unpack();
         if (propsDict.hasOwnProperty('Visible')) {
             this._onVisibilityChanged();

--- a/js/ui/windowManager.js
+++ b/js/ui/windowManager.js
@@ -676,7 +676,12 @@ const WindowManager = new Lang.Class({
     },
 
     _slideSideComponentOut : function(shellwm, actor, onComplete, onOverwrite) {
-        let monitor = Main.layoutManager.monitors[actor.meta_window.get_monitor()];
+        let monitor = null;
+
+        if (actor.meta_window) {
+            monitor = Main.layoutManager.monitors[actor.meta_window.get_monitor()];
+        }
+
         if (!monitor) {
             onComplete.apply(this, [shellwm, actor]);
             return;


### PR DESCRIPTION
The error happens when the MetaWindow of the give actor in
_slideSideComponentOut may be null.

This may not solve the whole issue, please see my comments in the task.

https://phabricator.endlessm.com/T10999