### PR TITLE
workspace: properly check for unmapped actors

### DIFF
--- a/js/ui/workspace.js
+++ b/js/ui/workspace.js
@@ -1022,13 +1022,6 @@ const Workspace = new Lang.Class({
     positionWindows: function(flags) {
         this._positionWindowsFlags |= flags;
 
-        /* This might not be the best place for this check. It prevents the
-         * shell from crashing in _computeAllWindowSlots when launching the
-         * tutorial if the actor has not been added to the stage. See T3727.
-         */
-        if (!this.actor.mapped)
-            return;
-
         if (this._positionWindowsId > 0)
             return;
 

--- a/js/ui/workspace.js
+++ b/js/ui/workspace.js
@@ -1310,6 +1310,7 @@ const Workspace = new Lang.Class({
             Mainloop.idle_add(Lang.bind(this,
                                         function () {
                                             if (this.actor &&
+                                                this.actor.mapped &&
                                                 metaWin.get_compositor_private() &&
                                                 metaWin.get_workspace() == this.metaWorkspace)
                                                 this._doAddWindow(metaWin);


### PR DESCRIPTION
When dealing with unmapped actors, Shell crashes since
St cannot create a theme node and ends up crashing. It
affects important applications such as eos-tutorial.

The proposed solution introduced another issue when an
unmapped window shows up since it completely aborts the
positioning code, which is something we want to do in the
majority of cases.

This commit places the check for unmapped windows before
adding the window, which fixes both the crash and the hot
corner issue.

https://phabricator.endlessm.com/T11146