### PR TITLE
Load fallback image-missing image when no other icon was loaded

### DIFF
--- a/src/st/st-texture-cache.c
+++ b/src/st/st-texture-cache.c
@@ -31,6 +31,8 @@
 #define CACHE_PREFIX_FILE "file:"
 #define CACHE_PREFIX_FILE_FOR_CAIRO "file-for-cairo:"
 
+#define IMAGE_MISSING_ICON_NAME "image-missing"
+
 struct _StTextureCachePrivate
 {
   GtkIconTheme *icon_theme;
@@ -884,7 +886,12 @@ load_gicon_with_colors (StTextureCache     *cache,
 
   info = gtk_icon_theme_lookup_by_gicon (theme, icon, size, GTK_ICON_LOOKUP_USE_BUILTIN);
   if (info == NULL)
-    return NULL;
+    {
+      /* Do not give up without even trying to pick the image-missing fallback icon. */
+      info = gtk_icon_theme_lookup_icon (theme, IMAGE_MISSING_ICON_NAME, size, GTK_ICON_LOOKUP_USE_BUILTIN);
+      if (info == NULL)
+        return NULL;
+    }
 
   gicon_string = g_icon_to_string (icon);
   /* A return value of NULL indicates that the icon can not be serialized,


### PR DESCRIPTION
If a given icon is not available for neither the current theme nor any
of the fallback options (default theme -"Adwaita", "gnome"...), the
call to gtk_icon_theme_lookup_by_gicon() will return a NULL value, which
returned by the Shell Toolkit as is, causing trouble in the Shell's JS
code when calling shell_app_create_icon_texture() to create an icon.

To at least mitigate the chances of this having this issue happening, we
should at least try to load the standad 'image-missing' icon from the
Icon Naming Specification spec when we receive a NULL here, so that
at least we try to show something to the user, even if it's ugly.

Upstream issue: https://bugzilla.gnome.org/show_bug.cgi?id=766391

https://phabricator.endlessm.com/T11550