### PR TITLE
iconGrid: sync editable and selectable properties of ClutterText

### DIFF
--- a/js/ui/iconGrid.js
+++ b/js/ui/iconGrid.js
@@ -57,8 +57,12 @@ const EditableLabel = new Lang.Class({
         this.parent(params);
 
         this.clutter_text.editable = false;
+        this.clutter_text.selectable = false;
         this.clutter_text.x_align = Clutter.ActorAlign.CENTER;
         this.clutter_text.ellipsize = Pango.EllipsizeMode.END;
+
+        this.clutter_text.bind_property('editable', this.clutter_text, 'selectable',
+            GObject.BindingFlags.BIDIRECTIONAL | GObject.BindingFlags.SYNC_CREATE);
 
         this._activateId = 0;
         this._keyFocusId = 0;


### PR DESCRIPTION
With clutter 1.26, ClutterText will never propagate button press events
if it is selectable. We don't actually need our ClutterText to be
selectable except when we are in edit mode, so keep the editable and
selectable properties in sync. This fixes a regression caused by clutter
1.26 where it became impossible to rename desktop icons.

https://phabricator.endlessm.com/T12228