### PR TITLE
main: initialize layout manager before workspace monitor

### DIFF
--- a/js/ui/main.js
+++ b/js/ui/main.js
@@ -175,11 +175,15 @@ function _initializeUI() {
     windowAttentionHandler = new WindowAttentionHandler.WindowAttentionHandler();
     componentManager = new Components.ComponentManager();
 
-    workspaceMonitor = new WorkspaceMonitor.WorkspaceMonitor();
-    desktopAppClient = new AppActivation.DesktopAppClient();
-
+    /*
+     * Since workspaceMonitor expects layoutManager to be ready, initialize it
+     * before workspaceMonitor
+     */
     layoutManager.init();
     overview.init();
+
+    workspaceMonitor = new WorkspaceMonitor.WorkspaceMonitor();
+    desktopAppClient = new AppActivation.DesktopAppClient();
 
     global.screen.override_workspace_layout(Meta.ScreenCorner.TOPLEFT,
                                             false, -1, 1);


### PR DESCRIPTION
WorkspaceMonitor connects to a bunch of signals that depends
on the window manager. These signals are not synchronized in
any way with the rest of the codebase.

Given a fast-enough initialization, the WorkspaceMonitor instance
can try to load the overview before the overview is ready, since
both the overview and the layout manager are initialized after
WorkspaceMonitor.

Fix that by initializing the layoutManager and overview before
the WorkspaceMonitor, ensuring that we always have a valid overview
to animate.

https://phabricator.endlessm.com/T12522