### PR TITLE
theme: add top margin to the search entry

### DIFF
--- a/data/theme/gnome-shell.css
+++ b/data/theme/gnome-shell.css
@@ -906,6 +906,7 @@ StScrollBar StButton#vhandle:active {
     width: 300px;
     padding-left: 8px;
     padding-right: 4px;
+    margin-top: 8px;
 
     font-family: lato, sans-serif;
     font-size: 11.5pt;

--- a/js/ui/viewSelector.js
+++ b/js/ui/viewSelector.js
@@ -124,6 +124,7 @@ const ViewsDisplayLayout = new Lang.Class({
         let entryHeight = this._entry.get_preferred_height(availWidth)[1];
         let themeNode = this._entry.get_theme_node();
         let entryMinPadding = themeNode.get_length('-minimum-vpadding');
+        let entryTopMargin = themeNode.get_length('margin-top');
         entryHeight += entryMinPadding * 2;
 
         // AllView height
@@ -132,7 +133,7 @@ const ViewsDisplayLayout = new Lang.Class({
         this._heightAboveEntry = this._centeredHeightAbove(entryHeight, heightAboveGrid);
 
         let entryBox = box.copy();
-        entryBox.y1 = this._heightAboveEntry;
+        entryBox.y1 = this._heightAboveEntry + entryTopMargin;
         entryBox.y2 = entryBox.y1 + entryHeight;
         this._entry.allocate(entryBox, flags);
 


### PR DESCRIPTION
In order to compensate the blank pixels around the icons - which
we can't remove -, also consider the margin-top CSS property to
calculate the height of the search entry.

https://phabricator.endlessm.com/T4924