### PR TITLE
taskbar-pins: add eos-installer icon (when image-booted)

### DIFF
--- a/data/org.gnome.shell.gschema.xml.in.in
+++ b/data/org.gnome.shell.gschema.xml.in.in
@@ -189,7 +189,7 @@
       </_description>
     </key>
     <key name="taskbar-pins" type="as">
-      <default>[ 'org.gnome.Software.desktop', 'chromium-browser.desktop', 'org.gnome.Nautilus.desktop' ]</default>
+      <default>[ 'org.gnome.Software.desktop', 'chromium-browser.desktop', 'org.gnome.Nautilus.desktop', 'eos-installer.desktop' ]</default>
       <_summary>List of desktop file IDs for applications pinned to taskbar</_summary>
       <_description>
         The applications corresponding to these identifiers will be displayed in


### PR DESCRIPTION
In general, this will actually have no effect: the taskbar ignores
desktop files that don't exist, and the eos-installer.desktop file
generally does not exist.

But when we are booted from an installable image, eos-installer.desktop
will be magicked into place. This way, if the user opts to "Try Endless"
during the FBE, they can still run eos-installer without rebooting.

https://phabricator.endlessm.com/T12548