### PR TITLE
eos-launch: fix for new application IDs syntax

### DIFF
--- a/js/misc/eos-launch.js
+++ b/js/misc/eos-launch.js
@@ -28,10 +28,10 @@ function getLocalizedAppNames(appName) {
         // discard variants with an encoding
         return (variant.indexOf('.') == -1)
     }).forEach(function(variant) {
-        appNames.push(appName + '-' + variant);
+        appNames.push(appName + '.' + variant);
     });
 
-    appNames.push(appName + '-en');
+    appNames.push(appName + '.en');
     return appNames;
 }
 


### PR DESCRIPTION
We use dots now instead of hyphens. Fix eos-launch to also use dots, or
it will always fail when launching applications.

https://phabricator.endlessm.com/T12576