### PR TITLE
iconGridLayout: fix fallback when no defaults found

### DIFF
--- a/js/ui/iconGridLayout.js
+++ b/js/ui/iconGridLayout.js
@@ -122,7 +122,9 @@ const IconGridLayout = new Lang.Class({
         if (iconTree === null || iconTree.n_children() == 0) {
             log('No icon grid defaults found!');
             // At the minimum, put in something that avoids exceptions later
-            iconTree = GLib.Variant.new('a{sas}', { DESKTOP_GRID_ID: [] });
+            let fallback = {};
+            fallback[DESKTOP_GRID_ID] = [];
+            iconTree = GLib.Variant.new('a{sas}', fallback);
         }
 
         return iconTree;


### PR DESCRIPTION
Variables can't be used as key names in literals like this (barring some
futuristic syntax I don't think our gjs supports yet), so the fallback
previously used the literal key 'DESKTOP_GRID_ID' rather than its value,
'desktop'.

Found while working on https://phabricator.endlessm.com/T12548