### PR TITLE
build: Remove eos_shell_real_DEPENDENCIES

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -211,7 +211,6 @@ eos_shell_real_SOURCES =		\
 eos_shell_real_CPPFLAGS = $(eos_shell_cflags)
 eos_shell_real_LDADD = libeos-shell.la libeos-shell-js.la libeos-shell-fx.la $(libeos_shell_la_LIBADD)
 eos_shell_real_LDFLAGS = @EOS_C_COVERAGE_LDFLAGS@
-eos_shell_real_DEPENDENCIES = libeos-shell.la libeos-shell-fx.la
 
 eos_shell_extension_prefs_SOURCES = 	\
 	gnome-shell-extension-prefs.c 	\


### PR DESCRIPTION
Defining this means that automake will not calculate it automatically
(https://www.gnu.org/software/automake/manual/automake.html#Linking). In
particular, this means that make will not wait until libeos-shell-js.la
libeos-shell-fx.la have completed before trying to link eos-shell-real.
Since libeos-shell-fx.la is a C++ library, it's likely that it won't be
complete before make schedules the eos-shell-real link.

Automake will add all the LDADD objects to DEPENDENCIES itself, and
everything will be fine. You really only want to be defining
DEPENDENCIES yourself in special cases.