### PR TITLE
Revert "appDisplay: sync/set hover on the right actor"

### DIFF
--- a/js/ui/appDisplay.js
+++ b/js/ui/appDisplay.js
@@ -1355,7 +1355,7 @@ const ViewIcon = new Lang.Class({
 
         this._menuManager.addMenu(this._menu);
 
-        this.iconButton.set_hover(true);
+        this.actor.set_hover(true);
         this._menu.popup();
         this._menuManager.ignoreRelease();
 
@@ -1363,7 +1363,7 @@ const ViewIcon = new Lang.Class({
     },
 
     _onMenuPoppedDown: function() {
-        this.iconButton.sync_hover();
+        this.actor.sync_hover();
     },
 
     _createPopupMenu: function() {
@@ -1380,7 +1380,7 @@ const ViewIcon = new Lang.Class({
     },
 
     _onLabelCancel: function() {
-        this.iconButton.sync_hover();
+        this.actor.sync_hover();
     },
 
     _scaleIn: function() {
@@ -1463,7 +1463,7 @@ const ViewIcon = new Lang.Class({
     },
 
     setDragHoverState: function(state) {
-        this.iconButton.set_hover(state);
+        this.actor.set_hover(state);
     },
 
     handleIconDrop: function(source) {


### PR DESCRIPTION
This reverts commit 8c4ae335b51ab4b141f7580e5c0779fccae266f4.

This was actually marked as CR fail earlier, because it broke hovering over the trash can, but I didn't check phabricator before looking at the code.

https://phabricator.endlessm.com/T13331