### PR TITLE
appDisplay: unset drag hover state when resetting drag view

### DIFF
--- a/js/ui/appDisplay.js
+++ b/js/ui/appDisplay.js
@@ -661,6 +661,10 @@ const AllView = new Lang.Class({
     _resetDragViewState: function() {
         this._resetNudgeState();
 
+        if (this._onIconIdx > -1) {
+            this._setDragHoverState(false);
+        }
+
         this._insertIdx = -1;
         this._onIconIdx = -1;
         this._lastCursorLocation = -1;


### PR DESCRIPTION
This code path will be hit when an icon is dragged outside of the view
boundaries.

https://phabricator.endlessm.com/T13331