### PR TITLE
appDisplay: be more careful when resetting drag hover state

### DIFF
--- a/js/ui/appDisplay.js
+++ b/js/ui/appDisplay.js
@@ -661,10 +661,6 @@ const AllView = new Lang.Class({
     _resetDragViewState: function() {
         this._resetNudgeState();
 
-        if (this._onIconIdx > -1) {
-            this._setDragHoverState(false);
-        }
-
         this._insertIdx = -1;
         this._onIconIdx = -1;
         this._lastCursorLocation = -1;
@@ -752,6 +748,10 @@ const AllView = new Lang.Class({
         }
 
         if (dragView != this._dragView) {
+            if (this._dragView && this._onIconIdx > -1) {
+                this._setDragHoverState(false);
+            }
+
             this._resetDragViewState();
             this._dragView = dragView;
         }


### PR DESCRIPTION
Instead of always calling it from _resetDragViewState() which is called
from multiple locations, call it from where we were hitting the
bug in the first place.

https://phabricator.endlessm.com/T13331