### PR TITLE
service: No need to deep-unpack the property variant

### DIFF
--- a/js/ui/components/codingGameService.js
+++ b/js/ui/components/codingGameService.js
@@ -33,7 +33,7 @@ const CodingChatboxTextService = new Lang.Class({
             return;
         }
 
-        let currentlyListeningFor = this._service.currently_listening_for_events.deep_unpack();
+        let currentlyListeningFor = this._service.currently_listening_for_events;
 
         // Disconnect any handlers not in the list
         Object.keys(this._signalHandlers).filter(function(name) {


### PR DESCRIPTION
For 'as' this is done automatically

This fixes a bug found when working on T14320 (leftover from T16313)

https://phabricator.endlessm.com/T14320