### PR TITLE
tests: Destroy GjsContext before exit

### DIFF
--- a/src/run-js-test.c
+++ b/src/run-js-test.c
@@ -161,6 +161,7 @@ main(int argc, char **argv)
   if (coverage && code == 0)
     gjs_coverage_write_statistics (coverage, coverage_output_path);
 
+  g_object_unref (js_context);
   g_free (script);
   exit (code);
 }


### PR DESCRIPTION
This will be required in the upcoming version of GJS.

https://bugzilla.gnome.org/show_bug.cgi?id=775374
https://phabricator.endlessm.com/T14460