### PR TITLE
CodeView: launch GNOME Builder with the manifest of the application

### DIFF
--- a/js/ui/codingManager.js
+++ b/js/ui/codingManager.js
@@ -235,6 +235,11 @@ const CodingManager = new Lang.Class({
     },
 
     _switchToBuilder: function(actor, event, session) {
+        function constructCommand(appManifest) {
+            // add an app_id_override to the manifest to load
+            return appManifest.get_path() + '+' + session.actorApp.meta_window.get_flatpak_id() + '.Coding';
+        }
+
         if (!session.actorBuilder) {
             // get the manifest of the application
             // return early before we setup anything
@@ -249,7 +254,7 @@ const CodingManager = new Lang.Class({
             this._watchdogId = Mainloop.timeout_add(WATCHDOG_TIME,
                                                     Lang.bind(this, this._watchdogTimeout));
 
-            Util.trySpawn(['flatpak', 'run', 'org.gnome.Builder', '-s']);
+            Util.trySpawn(['flatpak', 'run', 'org.gnome.Builder', '-s', '-m', constructCommand(appManifest)]);
             animateBounce(session.buttonApp);
         } else {
             session.actorBuilder.meta_window.activate(global.get_current_time());


### PR DESCRIPTION
Pass the manifest of the application to GNOME Builder to
construct the workbench for the application source. Concatenate
an override app-id that will be used to launch the modified app
so that there are no conflicts with the already running
application. The application itself needs to set the
G_APPLICATION_CAN_OVERRIDE_APP_ID flag in order for this to
work.