### PR TITLE
Coding: being able to run GNOME Builder outside of a coding sesssion

### DIFF
--- a/js/ui/codingManager.js
+++ b/js/ui/codingManager.js
@@ -91,6 +91,9 @@ const CodingManager = new Lang.Class({
         this._cancelWatchdog();
 
         let session = this._sessions[this._sessions.length - 1];
+        if (!session)
+            return false;
+
         if (session.actorBuilder)
             return false;
         let tracker = Shell.WindowTracker.get_default();


### PR DESCRIPTION
We only should try to associate a Builder window with
a coding session if a coding session exists T14671.