### PR TITLE
CodeView: listen to overview hiding and showing to hide overlay buttons

### DIFF
--- a/js/ui/codingManager.js
+++ b/js/ui/codingManager.js
@@ -134,6 +134,8 @@ const CodingManager = new Lang.Class({
         session.sizeChangedIdApp = window.connect('size-changed', Lang.bind(this, this._updateAppSizeAndPosition, session));
 
         session.windowsRestackedId = Main.overview.connect('windows-restacked', Lang.bind(this, this._windowRestacked, session));
+        session.overviewHidingId = Main.overview.connect('hiding', Lang.bind(this, this._overviewHiding, session));
+        session.overviewShowingId = Main.overview.connect('showing', Lang.bind(this, this._overviewShowing, session));
         session.windowMinimizedId = global.window_manager.connect('minimize', Lang.bind(this, this._windowMinimized, session));
         session.windowUnminimizedId = global.window_manager.connect('unminimize', Lang.bind(this, this._windowUnminimized, session));
     },
@@ -178,6 +180,14 @@ const CodingManager = new Lang.Class({
         if (session.windowsRestackedId !== 0) {
             Main.overview.disconnect(session.windowsRestackedId);
             session.windowsRestackedId = 0;
+        }
+        if (session.overviewHidingId !== 0) {
+            Main.overview.disconnect(session.overviewHidingId);
+            session.overviewHidingId = 0;
+        }
+        if (session.overviewShowingId !== 0) {
+            Main.overview.disconnect(session.overviewShowingId);
+            session.overviewShowingId = 0;
         }
         if (session.windowMinimizedId !== 0) {
             global.window_manager.disconnect(session.windowMinimizedId);
@@ -460,6 +470,18 @@ const CodingManager = new Lang.Class({
         } else if (builderWindow === previousFocused) {
             session.buttonBuilder.hide();
         }
+    },
+
+    _overviewHiding: function(overview, session) {
+        session.buttonApp.show();
+        if (session.buttonBuilder)
+            session.buttonBuilder.show();
+    },
+
+    _overviewShowing: function(overview, session) {
+        session.buttonApp.hide();
+        if (session.buttonBuilder)
+            session.buttonBuilder.hide();
     },
 
     _prepareAnimate: function(src, dst, direction) {


### PR DESCRIPTION
When the desktop is shown and the windows are hidden and vice
versa we need to make sure the overlay buttons are hidden and
shown again in those cases. The overview emits signals for
those cases used at other places in the shell already.

In the handlers we do not try to figure out the current active
session window and hide/show the existing buttons in any case.

https://phabricator.endlessm.com/T14811