### PR TITLE
userWidget: Fix leak of UserWidget causing crashes

### DIFF
--- a/js/gdm/loginDialog.js
+++ b/js/gdm/loginDialog.js
@@ -1078,6 +1078,8 @@ const LoginDialog = new Lang.Class({
         this._promptLoginHint.hide();
 
         this._promptUser.set_child(null);
+        this._userWidget.destroy();
+        this._userWidget = null;
 
         this._updateSensitivity(true);
         this._promptEntry.set_text('');
@@ -1393,8 +1395,11 @@ const LoginDialog = new Lang.Class({
     },
 
     _beginVerificationForItem: function(item) {
-        let userWidget = new UserWidget.UserWidget(item.user);
-        this._promptUser.set_child(userWidget.actor);
+        if (this._userWidget != null)
+            this._userWidget.destroy();
+
+        this._userWidget = new UserWidget.UserWidget(item.user);
+        this._promptUser.set_child(this._userWidget.actor);
 
         let tasks = [function() {
                          let userName = item.user.get_user_name();
@@ -1423,6 +1428,11 @@ const LoginDialog = new Lang.Class({
         if (this._userManagerLoadedId) {
             this._userManager.disconnect(this._userManagerLoadedId);
             this._userManagerLoadedId = 0;
+        }
+
+        if (this._userWidget != null) {
+            this._userWidget.destroy();
+            this._userWidget = null;
         }
     },
 

--- a/js/ui/unlockDialog.js
+++ b/js/ui/unlockDialog.js
@@ -299,6 +299,9 @@ const UnlockDialog = new Lang.Class({
     destroy: function() {
         this._userVerifier.clear();
 
+        this._userWidget.destroy();
+        this._userWidget = null;
+
         this.parent();
     },
 


### PR DESCRIPTION
In the two places the UserWidget was used (the login dialog and unlock
dialog), a UserWidget was constructed, then its `actor` property was
added to the UI and used. The actor was destroyed once done with — but
the UserWidget itself was never destroyed (by calling its `destroy()`
method).

This resulted in a couple of signals remaining connected to the D-Bus
proxy for the org.freedesktop.login1.User instance which the widget was
representing — notably its `changed` signal. This is emitted (amongst
other times) when the list of sessions the user is in changes, which can
happen if the user logs in via SSH while also logged in graphically, for
example.

Consequently, if the lock screen had been used (and hence a UserWidget
created for the UnlockDialog), then the user’s session list changed, the
callback for `changed` was called with a set of widgets which had been
destroyed. It would try and set the user’s username on them, and crash
due to using the dangling widget pointers.

Fix that by explicitly destroying the UserWidget instances at
appropriate times in the lifecycles of LoginDialog and UnlockDialog.

Signed-off-by: Philip Withnall <withnall@endlessm.com>

https://phabricator.endlessm.com/T12270

---

I’ve tested this by monkey-patching it in a gnome-shell extension, rather than by rebuilding the shell with it; but the end result should be the same.