### PR TITLE
userWidget: Fix leaking instances

### DIFF
--- a/js/ui/userWidget.js
+++ b/js/ui/userWidget.js
@@ -16,6 +16,7 @@ const UserWidget = new Lang.Class({
 
         this.actor = new St.BoxLayout({ style_class: 'user-widget',
                                         vertical: false });
+        this.actor.connect('destroy', Lang.bind(this, this._onDestroy));
 
         this._avatar = new UserMenu.UserAvatarWidget(user);
         this.actor.add(this._avatar.actor,
@@ -36,7 +37,7 @@ const UserWidget = new Lang.Class({
             this._updateUser();
     },
 
-    destroy: function() {
+    _onDestroy: function() {
         if (this._userLoadedId != 0) {
             this._user.disconnect(this._userLoadedId);
             this._userLoadedId = 0;
@@ -46,8 +47,6 @@ const UserWidget = new Lang.Class({
             this._user.disconnect(this._userChangedId);
             this._userChangedId = 0;
         }
-
-        this.actor.destroy();
     },
 
     _updateUser: function() {


### PR DESCRIPTION
UserWidget instances should be destroyed when the actor is. That's
what consumer code expects since the destroy() method is never called.

https://bugzilla.gnome.org/show_bug.cgi?id=700807
https://phabricator.endlessm.com/T12270

---

Backported (no changes required) from [upstream](https://bugzilla.gnome.org/show_bug.cgi?id=700807) to fix the same problem as in PR #219.