### PR TITLE
CodeView: Desktop hide/show, handle case where Builder and app are vi…

### DIFF
--- a/js/ui/codingManager.js
+++ b/js/ui/codingManager.js
@@ -473,9 +473,15 @@ const CodingManager = new Lang.Class({
     },
 
     _overviewHiding: function(overview, session) {
-        session.buttonApp.show();
-        if (session.buttonBuilder)
+        let focusedWindow = global.display.get_focus_window();
+        if (!focusedWindow)
+            return;
+
+        // we only need to verify a Builder window exist
+        if (session.actorBuilder && session.actorBuilder.meta_window === focusedWindow)
             session.buttonBuilder.show();
+        else if (session.actorApp.meta_window === focusedWindow)
+            session.buttonApp.show();
     },
 
     _overviewShowing: function(overview, session) {


### PR DESCRIPTION
…sible

The coding session consists of two windows, the GNOME Builder
one and the application one, each window has an overlay button
respectively. When we hide the Desktop we only want to show
the one that is associated with the currently focused window.

Follow-up of: cd6fa28429934e2b877967af6085a1d68326c148

https://phabricator.endlessm.com/T14811