### PR TITLE
iconGridLayout: Store layout after using defaults

### DIFF
--- a/js/ui/iconGridLayout.js
+++ b/js/ui/iconGridLayout.js
@@ -118,6 +118,11 @@ const IconGridLayout = new Lang.Class({
                     }
                 }
             }
+
+            // Store the current layout so we guarantee the user sees the same
+            // configuration after reboot
+            let newLayout = GLib.Variant.new('a{sas}', iconTree);
+            global.settings.set_value(SCHEMA_KEY, newLayout);
         }
 
         this._iconTree = iconTree;


### PR DESCRIPTION
When no icon layout is configured, then the default values are used but
never stored which means that the logic for getting the default values
will be executed again (until the gsetting for the layout is modified).

This may be a problem because what the user saw after logging in may not
be what will be shown the next time they start a session:
e.g. we are replacing the Chromium icon by the Google Chrome one
dynamically in the list of default icons; this logic is based on a
gsetting so, if we do not store that default configuration and the
mentioned gsetting is changed, the list of icons may be different next
time the user starts the session.

This patch always makes sure that the default grid of icons is also
stored and not simply shown, to ensure consistency in every reboot.

https://phabricator.endlessm.com/T15185