### PR TITLE
iconGridLayout: Provide default for missing icon grid files

### DIFF
--- a/js/ui/iconGridLayout.js
+++ b/js/ui/iconGridLayout.js
@@ -128,14 +128,14 @@ const IconGridLayout = new Lang.Class({
     },
 
     _mergeJsonStrings: function(base, override, prepend, append) {
-        let baseNode = null;
+        let baseNode = {};
         let prependNode = null;
         let appendNode = null;
         // If any image default override matches the user's locale,
         // give that priority over the default from the base OS
         if (override) {
             baseNode = JSON.parse(override);
-        } else {
+        } else if (base) {
             baseNode = JSON.parse(base);
         }
         if (prepend) {


### PR DESCRIPTION
This makes the default simply an empty icon grid, avoiding a crash if the
icon grid files are not present.

https://phabricator.endlessm.com/T15606