### PR TITLE
T15644 update errors

### DIFF
--- a/js/ui/components/updaterManager.js
+++ b/js/ui/components/updaterManager.js
@@ -267,6 +267,12 @@ const UpdaterManager = new Lang.Class({
             return;
         }
 
+        // We don’t want to notify of errors arising from being a dev-converted
+        // system.
+        if (this._proxy.ErrorName == 'com.endlessm.Updater.Error.NotOstreeSystem') {
+            return;
+        }
+
         this._ensureSource();
 
         this._notification = new UpdaterNotification(this._source,


### PR DESCRIPTION
A few updates to `updaterManager.js` to avoid showing failure notifications on dev-converted systems, and to load the new eos-updater configuration files.

https://phabricator.endlessm.com/T15644