### PR TITLE
updaterManager: Fix capitalisation of strings in notifications

### DIFF
--- a/js/ui/components/updaterManager.js
+++ b/js/ui/components/updaterManager.js
@@ -219,9 +219,9 @@ const UpdaterManager = new Lang.Class({
         this._ensureSource();
 
         this._notification = new UpdaterNotification(this._source,
-            _("Updates available"),
+            _("Updates Available"),
             _("Software updates are available for your system"));
-        this._notification.addButton('download-updates', _("Download now"));
+        this._notification.addButton('download-updates', _("Download Now"));
 
         this._sendNotification();
     },
@@ -234,9 +234,9 @@ const UpdaterManager = new Lang.Class({
         this._ensureSource();
 
         this._notification = new UpdaterNotification(this._source,
-            _("Updates ready"),
+            _("Updates Ready"),
             _("Software updates are ready to be installed on your system"));
-        this._notification.addButton('apply-updates', _("Install now"));
+        this._notification.addButton('apply-updates', _("Install Now"));
 
         this._sendNotification();
     },
@@ -245,9 +245,9 @@ const UpdaterManager = new Lang.Class({
         this._ensureSource();
 
         this._notification = new UpdaterNotification(this._source,
-            _("Updates installed"),
+            _("Updates Installed"),
             _("Software updates were installed on your system"));
-        this._notification.addButton('restart-updates', _("Restart now"));
+        this._notification.addButton('restart-updates', _("Restart Now"));
 
         this._sendNotification();
     },
@@ -276,7 +276,7 @@ const UpdaterManager = new Lang.Class({
         this._ensureSource();
 
         this._notification = new UpdaterNotification(this._source,
-            _("Update failed"),
+            _("Update Failed"),
             _("We could not update your system"));
 
         this._sendNotification();

--- a/po/af.po
+++ b/po/af.po
@@ -546,7 +546,7 @@ msgid "Software Update"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:204
-msgid "Updates available"
+msgid "Updates Available"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:205
@@ -554,11 +554,11 @@ msgid "Software updates are available for your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:206
-msgid "Download now"
+msgid "Download Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:219
-msgid "Updates ready"
+msgid "Updates Ready"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:220
@@ -566,11 +566,11 @@ msgid "Software updates are ready to be installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:221
-msgid "Install now"
+msgid "Install Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:230
-msgid "Updates installed"
+msgid "Updates Installed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:231
@@ -578,11 +578,11 @@ msgid "Software updates were installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:232
-msgid "Restart now"
+msgid "Restart Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:255
-msgid "Update failed"
+msgid "Update Failed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:256

--- a/po/an.po
+++ b/po/an.po
@@ -547,7 +547,7 @@ msgid "Software Update"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:204
-msgid "Updates available"
+msgid "Updates Available"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:205
@@ -555,11 +555,11 @@ msgid "Software updates are available for your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:206
-msgid "Download now"
+msgid "Download Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:219
-msgid "Updates ready"
+msgid "Updates Ready"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:220
@@ -567,11 +567,11 @@ msgid "Software updates are ready to be installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:221
-msgid "Install now"
+msgid "Install Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:230
-msgid "Updates installed"
+msgid "Updates Installed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:231
@@ -579,11 +579,11 @@ msgid "Software updates were installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:232
-msgid "Restart now"
+msgid "Restart Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:255
-msgid "Update failed"
+msgid "Update Failed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:256

--- a/po/ar.po
+++ b/po/ar.po
@@ -551,7 +551,7 @@ msgid "Software Update"
 msgstr "تحديث البرامج"
 
 #: ../js/ui/components/updaterManager.js:204
-msgid "Updates available"
+msgid "Updates Available"
 msgstr "التحديثات المتوفرة"
 
 #: ../js/ui/components/updaterManager.js:205
@@ -559,11 +559,11 @@ msgid "Software updates are available for your system"
 msgstr "تتوفر تحديثات برامج لنظامك"
 
 #: ../js/ui/components/updaterManager.js:206
-msgid "Download now"
+msgid "Download Now"
 msgstr "تنزيل الآن"
 
 #: ../js/ui/components/updaterManager.js:219
-msgid "Updates ready"
+msgid "Updates Ready"
 msgstr "التحديثات جاهزة"
 
 #: ../js/ui/components/updaterManager.js:220
@@ -571,11 +571,11 @@ msgid "Software updates are ready to be installed on your system"
 msgstr "تحديثات البرامج جاهزة ليتم تثبيتها على النظام الخاص بك"
 
 #: ../js/ui/components/updaterManager.js:221
-msgid "Install now"
+msgid "Install Now"
 msgstr "تثبيت الآن"
 
 #: ../js/ui/components/updaterManager.js:230
-msgid "Updates installed"
+msgid "Updates Installed"
 msgstr "التحديثات المثبّتة"
 
 #: ../js/ui/components/updaterManager.js:231
@@ -583,11 +583,11 @@ msgid "Software updates were installed on your system"
 msgstr "تم تثبيت تحديثات البرامج على جهازك"
 
 #: ../js/ui/components/updaterManager.js:232
-msgid "Restart now"
+msgid "Restart Now"
 msgstr "أعِد التشغيل الآن"
 
 #: ../js/ui/components/updaterManager.js:255
-msgid "Update failed"
+msgid "Update Failed"
 msgstr "فشل تحديث"
 
 #: ../js/ui/components/updaterManager.js:256

--- a/po/as.po
+++ b/po/as.po
@@ -546,7 +546,7 @@ msgid "Software Update"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:204
-msgid "Updates available"
+msgid "Updates Available"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:205
@@ -554,11 +554,11 @@ msgid "Software updates are available for your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:206
-msgid "Download now"
+msgid "Download Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:219
-msgid "Updates ready"
+msgid "Updates Ready"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:220
@@ -566,11 +566,11 @@ msgid "Software updates are ready to be installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:221
-msgid "Install now"
+msgid "Install Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:230
-msgid "Updates installed"
+msgid "Updates Installed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:231
@@ -578,11 +578,11 @@ msgid "Software updates were installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:232
-msgid "Restart now"
+msgid "Restart Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:255
-msgid "Update failed"
+msgid "Update Failed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:256

--- a/po/ast.po
+++ b/po/ast.po
@@ -545,7 +545,7 @@ msgid "Software Update"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:204
-msgid "Updates available"
+msgid "Updates Available"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:205
@@ -553,11 +553,11 @@ msgid "Software updates are available for your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:206
-msgid "Download now"
+msgid "Download Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:219
-msgid "Updates ready"
+msgid "Updates Ready"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:220
@@ -565,11 +565,11 @@ msgid "Software updates are ready to be installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:221
-msgid "Install now"
+msgid "Install Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:230
-msgid "Updates installed"
+msgid "Updates Installed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:231
@@ -577,11 +577,11 @@ msgid "Software updates were installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:232
-msgid "Restart now"
+msgid "Restart Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:255
-msgid "Update failed"
+msgid "Update Failed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:256

--- a/po/be.po
+++ b/po/be.po
@@ -546,7 +546,7 @@ msgid "Software Update"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:204
-msgid "Updates available"
+msgid "Updates Available"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:205
@@ -554,11 +554,11 @@ msgid "Software updates are available for your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:206
-msgid "Download now"
+msgid "Download Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:219
-msgid "Updates ready"
+msgid "Updates Ready"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:220
@@ -566,11 +566,11 @@ msgid "Software updates are ready to be installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:221
-msgid "Install now"
+msgid "Install Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:230
-msgid "Updates installed"
+msgid "Updates Installed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:231
@@ -578,11 +578,11 @@ msgid "Software updates were installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:232
-msgid "Restart now"
+msgid "Restart Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:255
-msgid "Update failed"
+msgid "Update Failed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:256

--- a/po/bg.po
+++ b/po/bg.po
@@ -546,7 +546,7 @@ msgid "Software Update"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:204
-msgid "Updates available"
+msgid "Updates Available"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:205
@@ -554,11 +554,11 @@ msgid "Software updates are available for your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:206
-msgid "Download now"
+msgid "Download Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:219
-msgid "Updates ready"
+msgid "Updates Ready"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:220
@@ -566,11 +566,11 @@ msgid "Software updates are ready to be installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:221
-msgid "Install now"
+msgid "Install Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:230
-msgid "Updates installed"
+msgid "Updates Installed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:231
@@ -578,11 +578,11 @@ msgid "Software updates were installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:232
-msgid "Restart now"
+msgid "Restart Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:255
-msgid "Update failed"
+msgid "Update Failed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:256

--- a/po/bn.po
+++ b/po/bn.po
@@ -546,7 +546,7 @@ msgid "Software Update"
 msgstr "সফটওয়্যার হালনাগাদ "
 
 #: ../js/ui/components/updaterManager.js:204
-msgid "Updates available"
+msgid "Updates Available"
 msgstr "হালনাগাদ করা যাবে "
 
 #: ../js/ui/components/updaterManager.js:205
@@ -554,11 +554,11 @@ msgid "Software updates are available for your system"
 msgstr "আপনার সিস্টেমের জন্য সফটওয়্যার হালনাগাদ করা যাবে "
 
 #: ../js/ui/components/updaterManager.js:206
-msgid "Download now"
+msgid "Download Now"
 msgstr "নামান এখনই "
 
 #: ../js/ui/components/updaterManager.js:219
-msgid "Updates ready"
+msgid "Updates Ready"
 msgstr "নতুনাবস্থা তৈরি "
 
 #: ../js/ui/components/updaterManager.js:220
@@ -566,11 +566,11 @@ msgid "Software updates are ready to be installed on your system"
 msgstr "সফটওয়্যার নতুনভাবে আপনার সিস্টেমে নেবার জন্য তৈরি  "
 
 #: ../js/ui/components/updaterManager.js:221
-msgid "Install now"
+msgid "Install Now"
 msgstr "এখনই নিন "
 
 #: ../js/ui/components/updaterManager.js:230
-msgid "Updates installed"
+msgid "Updates Installed"
 msgstr "হালনাগাদগুলো সংস্থাপিত হয়েছে "
 
 #: ../js/ui/components/updaterManager.js:231
@@ -578,11 +578,11 @@ msgid "Software updates were installed on your system"
 msgstr "সফটওয়্যারের নতুন অবস্থাটি আপনার সিস্টেমে নেয়া হয়েছে"
 
 #: ../js/ui/components/updaterManager.js:232
-msgid "Restart now"
+msgid "Restart Now"
 msgstr "আবার চালু করুন "
 
 #: ../js/ui/components/updaterManager.js:255
-msgid "Update failed"
+msgid "Update Failed"
 msgstr "হালনাগাদ ব্যর্থ হয়েছে "
 
 #: ../js/ui/components/updaterManager.js:256

--- a/po/bn_IN.po
+++ b/po/bn_IN.po
@@ -545,7 +545,7 @@ msgid "Software Update"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:204
-msgid "Updates available"
+msgid "Updates Available"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:205
@@ -553,11 +553,11 @@ msgid "Software updates are available for your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:206
-msgid "Download now"
+msgid "Download Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:219
-msgid "Updates ready"
+msgid "Updates Ready"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:220
@@ -565,11 +565,11 @@ msgid "Software updates are ready to be installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:221
-msgid "Install now"
+msgid "Install Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:230
-msgid "Updates installed"
+msgid "Updates Installed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:231
@@ -577,11 +577,11 @@ msgid "Software updates were installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:232
-msgid "Restart now"
+msgid "Restart Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:255
-msgid "Update failed"
+msgid "Update Failed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:256

--- a/po/bs.po
+++ b/po/bs.po
@@ -545,7 +545,7 @@ msgid "Software Update"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:204
-msgid "Updates available"
+msgid "Updates Available"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:205
@@ -553,11 +553,11 @@ msgid "Software updates are available for your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:206
-msgid "Download now"
+msgid "Download Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:219
-msgid "Updates ready"
+msgid "Updates Ready"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:220
@@ -565,11 +565,11 @@ msgid "Software updates are ready to be installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:221
-msgid "Install now"
+msgid "Install Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:230
-msgid "Updates installed"
+msgid "Updates Installed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:231
@@ -577,11 +577,11 @@ msgid "Software updates were installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:232
-msgid "Restart now"
+msgid "Restart Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:255
-msgid "Update failed"
+msgid "Update Failed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:256

--- a/po/ca.po
+++ b/po/ca.po
@@ -547,7 +547,7 @@ msgid "Software Update"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:204
-msgid "Updates available"
+msgid "Updates Available"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:205
@@ -555,11 +555,11 @@ msgid "Software updates are available for your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:206
-msgid "Download now"
+msgid "Download Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:219
-msgid "Updates ready"
+msgid "Updates Ready"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:220
@@ -567,11 +567,11 @@ msgid "Software updates are ready to be installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:221
-msgid "Install now"
+msgid "Install Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:230
-msgid "Updates installed"
+msgid "Updates Installed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:231
@@ -579,11 +579,11 @@ msgid "Software updates were installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:232
-msgid "Restart now"
+msgid "Restart Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:255
-msgid "Update failed"
+msgid "Update Failed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:256

--- a/po/ca@valencia.po
+++ b/po/ca@valencia.po
@@ -547,7 +547,7 @@ msgid "Software Update"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:204
-msgid "Updates available"
+msgid "Updates Available"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:205
@@ -555,11 +555,11 @@ msgid "Software updates are available for your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:206
-msgid "Download now"
+msgid "Download Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:219
-msgid "Updates ready"
+msgid "Updates Ready"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:220
@@ -567,11 +567,11 @@ msgid "Software updates are ready to be installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:221
-msgid "Install now"
+msgid "Install Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:230
-msgid "Updates installed"
+msgid "Updates Installed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:231
@@ -579,11 +579,11 @@ msgid "Software updates were installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:232
-msgid "Restart now"
+msgid "Restart Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:255
-msgid "Update failed"
+msgid "Update Failed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:256

--- a/po/cs.po
+++ b/po/cs.po
@@ -550,7 +550,7 @@ msgid "Software Update"
 msgstr "Aktualizace software"
 
 #: ../js/ui/components/updaterManager.js:204
-msgid "Updates available"
+msgid "Updates Available"
 msgstr "Dostupné aktualizace"
 
 #: ../js/ui/components/updaterManager.js:205
@@ -558,11 +558,11 @@ msgid "Software updates are available for your system"
 msgstr "K dispozici jsou aktualizace software pro váš systém"
 
 #: ../js/ui/components/updaterManager.js:206
-msgid "Download now"
+msgid "Download Now"
 msgstr "Stáhnout nyní"
 
 #: ../js/ui/components/updaterManager.js:219
-msgid "Updates ready"
+msgid "Updates Ready"
 msgstr "Aktualizace připraveny"
 
 #: ../js/ui/components/updaterManager.js:220
@@ -570,11 +570,11 @@ msgid "Software updates are ready to be installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:221
-msgid "Install now"
+msgid "Install Now"
 msgstr "Instalovat nyní"
 
 #: ../js/ui/components/updaterManager.js:230
-msgid "Updates installed"
+msgid "Updates Installed"
 msgstr "Aktualizace nainstalovány"
 
 #: ../js/ui/components/updaterManager.js:231
@@ -582,11 +582,11 @@ msgid "Software updates were installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:232
-msgid "Restart now"
+msgid "Restart Now"
 msgstr "Restartovat nyní"
 
 #: ../js/ui/components/updaterManager.js:255
-msgid "Update failed"
+msgid "Update Failed"
 msgstr "Aktualizace selhala"
 
 #: ../js/ui/components/updaterManager.js:256

--- a/po/cy.po
+++ b/po/cy.po
@@ -544,7 +544,7 @@ msgid "Software Update"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:204
-msgid "Updates available"
+msgid "Updates Available"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:205
@@ -552,11 +552,11 @@ msgid "Software updates are available for your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:206
-msgid "Download now"
+msgid "Download Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:219
-msgid "Updates ready"
+msgid "Updates Ready"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:220
@@ -564,11 +564,11 @@ msgid "Software updates are ready to be installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:221
-msgid "Install now"
+msgid "Install Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:230
-msgid "Updates installed"
+msgid "Updates Installed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:231
@@ -576,11 +576,11 @@ msgid "Software updates were installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:232
-msgid "Restart now"
+msgid "Restart Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:255
-msgid "Update failed"
+msgid "Update Failed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:256

--- a/po/da.po
+++ b/po/da.po
@@ -546,7 +546,7 @@ msgid "Software Update"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:204
-msgid "Updates available"
+msgid "Updates Available"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:205
@@ -554,11 +554,11 @@ msgid "Software updates are available for your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:206
-msgid "Download now"
+msgid "Download Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:219
-msgid "Updates ready"
+msgid "Updates Ready"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:220
@@ -566,11 +566,11 @@ msgid "Software updates are ready to be installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:221
-msgid "Install now"
+msgid "Install Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:230
-msgid "Updates installed"
+msgid "Updates Installed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:231
@@ -578,11 +578,11 @@ msgid "Software updates were installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:232
-msgid "Restart now"
+msgid "Restart Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:255
-msgid "Update failed"
+msgid "Update Failed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:256

--- a/po/de.po
+++ b/po/de.po
@@ -555,7 +555,7 @@ msgid "Software Update"
 msgstr "Software-Update"
 
 #: ../js/ui/components/updaterManager.js:204
-msgid "Updates available"
+msgid "Updates Available"
 msgstr "Updates verfügbar"
 
 #: ../js/ui/components/updaterManager.js:205
@@ -563,11 +563,11 @@ msgid "Software updates are available for your system"
 msgstr "Es sind Software-Updates verfügbar"
 
 #: ../js/ui/components/updaterManager.js:206
-msgid "Download now"
+msgid "Download Now"
 msgstr "Jetzt herunterladen"
 
 #: ../js/ui/components/updaterManager.js:219
-msgid "Updates ready"
+msgid "Updates Ready"
 msgstr "Updates stehen bereit"
 
 #: ../js/ui/components/updaterManager.js:220
@@ -575,11 +575,11 @@ msgid "Software updates are ready to be installed on your system"
 msgstr "Software-Updates stehen zur Installation bereit"
 
 #: ../js/ui/components/updaterManager.js:221
-msgid "Install now"
+msgid "Install Now"
 msgstr "Jetzt installieren"
 
 #: ../js/ui/components/updaterManager.js:230
-msgid "Updates installed"
+msgid "Updates Installed"
 msgstr "Updates sind installiert"
 
 #: ../js/ui/components/updaterManager.js:231
@@ -587,11 +587,11 @@ msgid "Software updates were installed on your system"
 msgstr "Software-Updates sind installiert"
 
 #: ../js/ui/components/updaterManager.js:232
-msgid "Restart now"
+msgid "Restart Now"
 msgstr "Jetzt Neustarten"
 
 #: ../js/ui/components/updaterManager.js:255
-msgid "Update failed"
+msgid "Update Failed"
 msgstr "Update ist fehlgeschlagen"
 
 #: ../js/ui/components/updaterManager.js:256

--- a/po/el.po
+++ b/po/el.po
@@ -549,7 +549,7 @@ msgid "Software Update"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:204
-msgid "Updates available"
+msgid "Updates Available"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:205
@@ -557,11 +557,11 @@ msgid "Software updates are available for your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:206
-msgid "Download now"
+msgid "Download Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:219
-msgid "Updates ready"
+msgid "Updates Ready"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:220
@@ -569,11 +569,11 @@ msgid "Software updates are ready to be installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:221
-msgid "Install now"
+msgid "Install Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:230
-msgid "Updates installed"
+msgid "Updates Installed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:231
@@ -581,11 +581,11 @@ msgid "Software updates were installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:232
-msgid "Restart now"
+msgid "Restart Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:255
-msgid "Update failed"
+msgid "Update Failed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:256

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -547,7 +547,7 @@ msgid "Software Update"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:204
-msgid "Updates available"
+msgid "Updates Available"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:205
@@ -555,11 +555,11 @@ msgid "Software updates are available for your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:206
-msgid "Download now"
+msgid "Download Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:219
-msgid "Updates ready"
+msgid "Updates Ready"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:220
@@ -567,11 +567,11 @@ msgid "Software updates are ready to be installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:221
-msgid "Install now"
+msgid "Install Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:230
-msgid "Updates installed"
+msgid "Updates Installed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:231
@@ -579,11 +579,11 @@ msgid "Software updates were installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:232
-msgid "Restart now"
+msgid "Restart Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:255
-msgid "Update failed"
+msgid "Update Failed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:256

--- a/po/eo.po
+++ b/po/eo.po
@@ -550,7 +550,7 @@ msgid "Software Update"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:204
-msgid "Updates available"
+msgid "Updates Available"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:205
@@ -558,11 +558,11 @@ msgid "Software updates are available for your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:206
-msgid "Download now"
+msgid "Download Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:219
-msgid "Updates ready"
+msgid "Updates Ready"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:220
@@ -570,11 +570,11 @@ msgid "Software updates are ready to be installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:221
-msgid "Install now"
+msgid "Install Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:230
-msgid "Updates installed"
+msgid "Updates Installed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:231
@@ -582,11 +582,11 @@ msgid "Software updates were installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:232
-msgid "Restart now"
+msgid "Restart Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:255
-msgid "Update failed"
+msgid "Update Failed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:256

--- a/po/eos-desktop.pot
+++ b/po/eos-desktop.pot
@@ -544,7 +544,7 @@ msgid "Software Update"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:204
-msgid "Updates available"
+msgid "Updates Available"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:205
@@ -552,11 +552,11 @@ msgid "Software updates are available for your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:206
-msgid "Download now"
+msgid "Download Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:219
-msgid "Updates ready"
+msgid "Updates Ready"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:220
@@ -564,11 +564,11 @@ msgid "Software updates are ready to be installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:221
-msgid "Install now"
+msgid "Install Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:230
-msgid "Updates installed"
+msgid "Updates Installed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:231
@@ -576,11 +576,11 @@ msgid "Software updates were installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:232
-msgid "Restart now"
+msgid "Restart Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:255
-msgid "Update failed"
+msgid "Update Failed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:256

--- a/po/es.po
+++ b/po/es.po
@@ -555,7 +555,7 @@ msgid "Software Update"
 msgstr "Actualización de software"
 
 #: ../js/ui/components/updaterManager.js:204
-msgid "Updates available"
+msgid "Updates Available"
 msgstr "Actualizaciones disponibles"
 
 #: ../js/ui/components/updaterManager.js:205
@@ -563,11 +563,11 @@ msgid "Software updates are available for your system"
 msgstr "Hay actualizaciones disponibles para tu sistema"
 
 #: ../js/ui/components/updaterManager.js:206
-msgid "Download now"
+msgid "Download Now"
 msgstr "Descargar ahora"
 
 #: ../js/ui/components/updaterManager.js:219
-msgid "Updates ready"
+msgid "Updates Ready"
 msgstr "Actualizaciones listas"
 
 #: ../js/ui/components/updaterManager.js:220
@@ -575,11 +575,11 @@ msgid "Software updates are ready to be installed on your system"
 msgstr "Las actualizaciones están listas para instalar en tu sistema"
 
 #: ../js/ui/components/updaterManager.js:221
-msgid "Install now"
+msgid "Install Now"
 msgstr "Instalar ahora"
 
 #: ../js/ui/components/updaterManager.js:230
-msgid "Updates installed"
+msgid "Updates Installed"
 msgstr "Actualizaciones instaladas"
 
 #: ../js/ui/components/updaterManager.js:231
@@ -587,11 +587,11 @@ msgid "Software updates were installed on your system"
 msgstr "Las actualizaciones se han instalado en tu sistema"
 
 #: ../js/ui/components/updaterManager.js:232
-msgid "Restart now"
+msgid "Restart Now"
 msgstr "Reiniciar ahora"
 
 #: ../js/ui/components/updaterManager.js:255
-msgid "Update failed"
+msgid "Update Failed"
 msgstr "Hubo un error durante la actualización"
 
 #: ../js/ui/components/updaterManager.js:256

--- a/po/et.po
+++ b/po/et.po
@@ -546,7 +546,7 @@ msgid "Software Update"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:204
-msgid "Updates available"
+msgid "Updates Available"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:205
@@ -554,11 +554,11 @@ msgid "Software updates are available for your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:206
-msgid "Download now"
+msgid "Download Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:219
-msgid "Updates ready"
+msgid "Updates Ready"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:220
@@ -566,11 +566,11 @@ msgid "Software updates are ready to be installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:221
-msgid "Install now"
+msgid "Install Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:230
-msgid "Updates installed"
+msgid "Updates Installed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:231
@@ -578,11 +578,11 @@ msgid "Software updates were installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:232
-msgid "Restart now"
+msgid "Restart Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:255
-msgid "Update failed"
+msgid "Update Failed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:256

--- a/po/eu.po
+++ b/po/eu.po
@@ -547,7 +547,7 @@ msgid "Software Update"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:204
-msgid "Updates available"
+msgid "Updates Available"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:205
@@ -555,11 +555,11 @@ msgid "Software updates are available for your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:206
-msgid "Download now"
+msgid "Download Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:219
-msgid "Updates ready"
+msgid "Updates Ready"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:220
@@ -567,11 +567,11 @@ msgid "Software updates are ready to be installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:221
-msgid "Install now"
+msgid "Install Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:230
-msgid "Updates installed"
+msgid "Updates Installed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:231
@@ -579,11 +579,11 @@ msgid "Software updates were installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:232
-msgid "Restart now"
+msgid "Restart Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:255
-msgid "Update failed"
+msgid "Update Failed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:256

--- a/po/fa.po
+++ b/po/fa.po
@@ -546,7 +546,7 @@ msgid "Software Update"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:204
-msgid "Updates available"
+msgid "Updates Available"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:205
@@ -554,11 +554,11 @@ msgid "Software updates are available for your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:206
-msgid "Download now"
+msgid "Download Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:219
-msgid "Updates ready"
+msgid "Updates Ready"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:220
@@ -566,11 +566,11 @@ msgid "Software updates are ready to be installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:221
-msgid "Install now"
+msgid "Install Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:230
-msgid "Updates installed"
+msgid "Updates Installed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:231
@@ -578,11 +578,11 @@ msgid "Software updates were installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:232
-msgid "Restart now"
+msgid "Restart Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:255
-msgid "Update failed"
+msgid "Update Failed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:256

--- a/po/fi.po
+++ b/po/fi.po
@@ -548,7 +548,7 @@ msgid "Software Update"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:204
-msgid "Updates available"
+msgid "Updates Available"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:205
@@ -556,11 +556,11 @@ msgid "Software updates are available for your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:206
-msgid "Download now"
+msgid "Download Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:219
-msgid "Updates ready"
+msgid "Updates Ready"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:220
@@ -568,11 +568,11 @@ msgid "Software updates are ready to be installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:221
-msgid "Install now"
+msgid "Install Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:230
-msgid "Updates installed"
+msgid "Updates Installed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:231
@@ -580,11 +580,11 @@ msgid "Software updates were installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:232
-msgid "Restart now"
+msgid "Restart Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:255
-msgid "Update failed"
+msgid "Update Failed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:256

--- a/po/fil.po
+++ b/po/fil.po
@@ -544,7 +544,7 @@ msgid "Software Update"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:204
-msgid "Updates available"
+msgid "Updates Available"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:205
@@ -552,11 +552,11 @@ msgid "Software updates are available for your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:206
-msgid "Download now"
+msgid "Download Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:219
-msgid "Updates ready"
+msgid "Updates Ready"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:220
@@ -564,11 +564,11 @@ msgid "Software updates are ready to be installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:221
-msgid "Install now"
+msgid "Install Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:230
-msgid "Updates installed"
+msgid "Updates Installed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:231
@@ -576,11 +576,11 @@ msgid "Software updates were installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:232
-msgid "Restart now"
+msgid "Restart Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:255
-msgid "Update failed"
+msgid "Update Failed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:256

--- a/po/fr.po
+++ b/po/fr.po
@@ -555,7 +555,7 @@ msgid "Software Update"
 msgstr "Mise à jour logicielle"
 
 #: ../js/ui/components/updaterManager.js:204
-msgid "Updates available"
+msgid "Updates Available"
 msgstr "Mises à jour disponibles"
 
 #: ../js/ui/components/updaterManager.js:205
@@ -563,11 +563,11 @@ msgid "Software updates are available for your system"
 msgstr "Les mises à jour logicielles sont disponibles pour votre système"
 
 #: ../js/ui/components/updaterManager.js:206
-msgid "Download now"
+msgid "Download Now"
 msgstr "Télécharger maintenant"
 
 #: ../js/ui/components/updaterManager.js:219
-msgid "Updates ready"
+msgid "Updates Ready"
 msgstr "Mises à jour prête"
 
 #: ../js/ui/components/updaterManager.js:220
@@ -575,11 +575,11 @@ msgid "Software updates are ready to be installed on your system"
 msgstr "Les mises à jour logicielles sont prêtes à être installées sur votre système"
 
 #: ../js/ui/components/updaterManager.js:221
-msgid "Install now"
+msgid "Install Now"
 msgstr "Installer maintenant"
 
 #: ../js/ui/components/updaterManager.js:230
-msgid "Updates installed"
+msgid "Updates Installed"
 msgstr "Mises à jour installées"
 
 #: ../js/ui/components/updaterManager.js:231
@@ -587,11 +587,11 @@ msgid "Software updates were installed on your system"
 msgstr "Les mises à jour logicielles ont été installées sur votre système"
 
 #: ../js/ui/components/updaterManager.js:232
-msgid "Restart now"
+msgid "Restart Now"
 msgstr "Redémarrer maintenant"
 
 #: ../js/ui/components/updaterManager.js:255
-msgid "Update failed"
+msgid "Update Failed"
 msgstr "Echec d'une tentative de mise à jour"
 
 #: ../js/ui/components/updaterManager.js:256

--- a/po/fur.po
+++ b/po/fur.po
@@ -545,7 +545,7 @@ msgid "Software Update"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:204
-msgid "Updates available"
+msgid "Updates Available"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:205
@@ -553,11 +553,11 @@ msgid "Software updates are available for your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:206
-msgid "Download now"
+msgid "Download Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:219
-msgid "Updates ready"
+msgid "Updates Ready"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:220
@@ -565,11 +565,11 @@ msgid "Software updates are ready to be installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:221
-msgid "Install now"
+msgid "Install Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:230
-msgid "Updates installed"
+msgid "Updates Installed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:231
@@ -577,11 +577,11 @@ msgid "Software updates were installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:232
-msgid "Restart now"
+msgid "Restart Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:255
-msgid "Update failed"
+msgid "Update Failed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:256

--- a/po/ga.po
+++ b/po/ga.po
@@ -544,7 +544,7 @@ msgid "Software Update"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:204
-msgid "Updates available"
+msgid "Updates Available"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:205
@@ -552,11 +552,11 @@ msgid "Software updates are available for your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:206
-msgid "Download now"
+msgid "Download Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:219
-msgid "Updates ready"
+msgid "Updates Ready"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:220
@@ -564,11 +564,11 @@ msgid "Software updates are ready to be installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:221
-msgid "Install now"
+msgid "Install Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:230
-msgid "Updates installed"
+msgid "Updates Installed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:231
@@ -576,11 +576,11 @@ msgid "Software updates were installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:232
-msgid "Restart now"
+msgid "Restart Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:255
-msgid "Update failed"
+msgid "Update Failed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:256

--- a/po/gd.po
+++ b/po/gd.po
@@ -545,7 +545,7 @@ msgid "Software Update"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:204
-msgid "Updates available"
+msgid "Updates Available"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:205
@@ -553,11 +553,11 @@ msgid "Software updates are available for your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:206
-msgid "Download now"
+msgid "Download Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:219
-msgid "Updates ready"
+msgid "Updates Ready"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:220
@@ -565,11 +565,11 @@ msgid "Software updates are ready to be installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:221
-msgid "Install now"
+msgid "Install Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:230
-msgid "Updates installed"
+msgid "Updates Installed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:231
@@ -577,11 +577,11 @@ msgid "Software updates were installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:232
-msgid "Restart now"
+msgid "Restart Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:255
-msgid "Update failed"
+msgid "Update Failed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:256

--- a/po/gl.po
+++ b/po/gl.po
@@ -548,7 +548,7 @@ msgid "Software Update"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:204
-msgid "Updates available"
+msgid "Updates Available"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:205
@@ -556,11 +556,11 @@ msgid "Software updates are available for your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:206
-msgid "Download now"
+msgid "Download Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:219
-msgid "Updates ready"
+msgid "Updates Ready"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:220
@@ -568,11 +568,11 @@ msgid "Software updates are ready to be installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:221
-msgid "Install now"
+msgid "Install Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:230
-msgid "Updates installed"
+msgid "Updates Installed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:231
@@ -580,11 +580,11 @@ msgid "Software updates were installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:232
-msgid "Restart now"
+msgid "Restart Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:255
-msgid "Update failed"
+msgid "Update Failed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:256

--- a/po/gu.po
+++ b/po/gu.po
@@ -545,7 +545,7 @@ msgid "Software Update"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:204
-msgid "Updates available"
+msgid "Updates Available"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:205
@@ -553,11 +553,11 @@ msgid "Software updates are available for your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:206
-msgid "Download now"
+msgid "Download Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:219
-msgid "Updates ready"
+msgid "Updates Ready"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:220
@@ -565,11 +565,11 @@ msgid "Software updates are ready to be installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:221
-msgid "Install now"
+msgid "Install Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:230
-msgid "Updates installed"
+msgid "Updates Installed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:231
@@ -577,11 +577,11 @@ msgid "Software updates were installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:232
-msgid "Restart now"
+msgid "Restart Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:255
-msgid "Update failed"
+msgid "Update Failed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:256

--- a/po/he.po
+++ b/po/he.po
@@ -547,7 +547,7 @@ msgid "Software Update"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:204
-msgid "Updates available"
+msgid "Updates Available"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:205
@@ -555,11 +555,11 @@ msgid "Software updates are available for your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:206
-msgid "Download now"
+msgid "Download Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:219
-msgid "Updates ready"
+msgid "Updates Ready"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:220
@@ -567,11 +567,11 @@ msgid "Software updates are ready to be installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:221
-msgid "Install now"
+msgid "Install Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:230
-msgid "Updates installed"
+msgid "Updates Installed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:231
@@ -579,11 +579,11 @@ msgid "Software updates were installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:232
-msgid "Restart now"
+msgid "Restart Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:255
-msgid "Update failed"
+msgid "Update Failed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:256

--- a/po/hi.po
+++ b/po/hi.po
@@ -550,7 +550,7 @@ msgid "Software Update"
 msgstr "सॉफ्टवेयर अपडेट"
 
 #: ../js/ui/components/updaterManager.js:204
-msgid "Updates available"
+msgid "Updates Available"
 msgstr "अपडेट्स उपलब्ध हैं"
 
 #: ../js/ui/components/updaterManager.js:205
@@ -558,11 +558,11 @@ msgid "Software updates are available for your system"
 msgstr "सॉफ्टवेयर अपडेट्स आपके सिस्टम के लिए उपलब्ध हैं"
 
 #: ../js/ui/components/updaterManager.js:206
-msgid "Download now"
+msgid "Download Now"
 msgstr "अभी डाउनलोड करें"
 
 #: ../js/ui/components/updaterManager.js:219
-msgid "Updates ready"
+msgid "Updates Ready"
 msgstr "अप्डेट्स तैयार हैंं"
 
 #: ../js/ui/components/updaterManager.js:220
@@ -570,11 +570,11 @@ msgid "Software updates are ready to be installed on your system"
 msgstr "सॉफ्टवेयर अपडेट्स आपके सिस्टम पर इंंस्टॉल्ड किए जाने के लिए उपलब्ध हैं"
 
 #: ../js/ui/components/updaterManager.js:221
-msgid "Install now"
+msgid "Install Now"
 msgstr "अभी इंस्टॉल करें"
 
 #: ../js/ui/components/updaterManager.js:230
-msgid "Updates installed"
+msgid "Updates Installed"
 msgstr "अपडेट्स इंस्टॉल किए गए"
 
 #: ../js/ui/components/updaterManager.js:231
@@ -582,11 +582,11 @@ msgid "Software updates were installed on your system"
 msgstr "सॉफ्टवेयर अपडेट्स आपके सिस्टम पर इंस्टॉल किए गए"
 
 #: ../js/ui/components/updaterManager.js:232
-msgid "Restart now"
+msgid "Restart Now"
 msgstr "अभी रीस्टार्ट करें"
 
 #: ../js/ui/components/updaterManager.js:255
-msgid "Update failed"
+msgid "Update Failed"
 msgstr "अपडेट्स विफल हुए"
 
 #: ../js/ui/components/updaterManager.js:256

--- a/po/hu.po
+++ b/po/hu.po
@@ -548,7 +548,7 @@ msgid "Software Update"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:204
-msgid "Updates available"
+msgid "Updates Available"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:205
@@ -556,11 +556,11 @@ msgid "Software updates are available for your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:206
-msgid "Download now"
+msgid "Download Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:219
-msgid "Updates ready"
+msgid "Updates Ready"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:220
@@ -568,11 +568,11 @@ msgid "Software updates are ready to be installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:221
-msgid "Install now"
+msgid "Install Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:230
-msgid "Updates installed"
+msgid "Updates Installed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:231
@@ -580,11 +580,11 @@ msgid "Software updates were installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:232
-msgid "Restart now"
+msgid "Restart Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:255
-msgid "Update failed"
+msgid "Update Failed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:256

--- a/po/ia.po
+++ b/po/ia.po
@@ -545,7 +545,7 @@ msgid "Software Update"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:204
-msgid "Updates available"
+msgid "Updates Available"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:205
@@ -553,11 +553,11 @@ msgid "Software updates are available for your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:206
-msgid "Download now"
+msgid "Download Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:219
-msgid "Updates ready"
+msgid "Updates Ready"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:220
@@ -565,11 +565,11 @@ msgid "Software updates are ready to be installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:221
-msgid "Install now"
+msgid "Install Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:230
-msgid "Updates installed"
+msgid "Updates Installed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:231
@@ -577,11 +577,11 @@ msgid "Software updates were installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:232
-msgid "Restart now"
+msgid "Restart Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:255
-msgid "Update failed"
+msgid "Update Failed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:256

--- a/po/id.po
+++ b/po/id.po
@@ -549,7 +549,7 @@ msgid "Software Update"
 msgstr "Pembaruan Perangkat Lunak"
 
 #: ../js/ui/components/updaterManager.js:204
-msgid "Updates available"
+msgid "Updates Available"
 msgstr "Pembaruan tersedia"
 
 #: ../js/ui/components/updaterManager.js:205
@@ -557,11 +557,11 @@ msgid "Software updates are available for your system"
 msgstr "Pembaruan perangkat lunak tersedia untuk sistem Anda"
 
 #: ../js/ui/components/updaterManager.js:206
-msgid "Download now"
+msgid "Download Now"
 msgstr "Unduh sekarang"
 
 #: ../js/ui/components/updaterManager.js:219
-msgid "Updates ready"
+msgid "Updates Ready"
 msgstr "Pembaruan siap"
 
 #: ../js/ui/components/updaterManager.js:220
@@ -569,11 +569,11 @@ msgid "Software updates are ready to be installed on your system"
 msgstr "Pembaruan perangkat lunak siap dipasang pada sistem Anda"
 
 #: ../js/ui/components/updaterManager.js:221
-msgid "Install now"
+msgid "Install Now"
 msgstr "Pasang sekarang"
 
 #: ../js/ui/components/updaterManager.js:230
-msgid "Updates installed"
+msgid "Updates Installed"
 msgstr "Pembaruan telah dipasang"
 
 #: ../js/ui/components/updaterManager.js:231
@@ -581,11 +581,11 @@ msgid "Software updates were installed on your system"
 msgstr "Pembaruan perangkat lunak sudah dipasang pada sistem Anda"
 
 #: ../js/ui/components/updaterManager.js:232
-msgid "Restart now"
+msgid "Restart Now"
 msgstr "Mulai ulang sekarang"
 
 #: ../js/ui/components/updaterManager.js:255
-msgid "Update failed"
+msgid "Update Failed"
 msgstr "Gagal memperbarui"
 
 #: ../js/ui/components/updaterManager.js:256

--- a/po/is.po
+++ b/po/is.po
@@ -545,7 +545,7 @@ msgid "Software Update"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:204
-msgid "Updates available"
+msgid "Updates Available"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:205
@@ -553,11 +553,11 @@ msgid "Software updates are available for your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:206
-msgid "Download now"
+msgid "Download Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:219
-msgid "Updates ready"
+msgid "Updates Ready"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:220
@@ -565,11 +565,11 @@ msgid "Software updates are ready to be installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:221
-msgid "Install now"
+msgid "Install Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:230
-msgid "Updates installed"
+msgid "Updates Installed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:231
@@ -577,11 +577,11 @@ msgid "Software updates were installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:232
-msgid "Restart now"
+msgid "Restart Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:255
-msgid "Update failed"
+msgid "Update Failed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:256

--- a/po/it.po
+++ b/po/it.po
@@ -548,7 +548,7 @@ msgid "Software Update"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:204
-msgid "Updates available"
+msgid "Updates Available"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:205
@@ -556,11 +556,11 @@ msgid "Software updates are available for your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:206
-msgid "Download now"
+msgid "Download Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:219
-msgid "Updates ready"
+msgid "Updates Ready"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:220
@@ -568,11 +568,11 @@ msgid "Software updates are ready to be installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:221
-msgid "Install now"
+msgid "Install Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:230
-msgid "Updates installed"
+msgid "Updates Installed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:231
@@ -580,11 +580,11 @@ msgid "Software updates were installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:232
-msgid "Restart now"
+msgid "Restart Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:255
-msgid "Update failed"
+msgid "Update Failed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:256

--- a/po/ja.po
+++ b/po/ja.po
@@ -553,7 +553,7 @@ msgid "Software Update"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:204
-msgid "Updates available"
+msgid "Updates Available"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:205
@@ -561,11 +561,11 @@ msgid "Software updates are available for your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:206
-msgid "Download now"
+msgid "Download Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:219
-msgid "Updates ready"
+msgid "Updates Ready"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:220
@@ -573,11 +573,11 @@ msgid "Software updates are ready to be installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:221
-msgid "Install now"
+msgid "Install Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:230
-msgid "Updates installed"
+msgid "Updates Installed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:231
@@ -585,11 +585,11 @@ msgid "Software updates were installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:232
-msgid "Restart now"
+msgid "Restart Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:255
-msgid "Update failed"
+msgid "Update Failed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:256

--- a/po/kk.po
+++ b/po/kk.po
@@ -544,7 +544,7 @@ msgid "Software Update"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:204
-msgid "Updates available"
+msgid "Updates Available"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:205
@@ -552,11 +552,11 @@ msgid "Software updates are available for your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:206
-msgid "Download now"
+msgid "Download Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:219
-msgid "Updates ready"
+msgid "Updates Ready"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:220
@@ -564,11 +564,11 @@ msgid "Software updates are ready to be installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:221
-msgid "Install now"
+msgid "Install Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:230
-msgid "Updates installed"
+msgid "Updates Installed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:231
@@ -576,11 +576,11 @@ msgid "Software updates were installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:232
-msgid "Restart now"
+msgid "Restart Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:255
-msgid "Update failed"
+msgid "Update Failed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:256

--- a/po/km.po
+++ b/po/km.po
@@ -544,7 +544,7 @@ msgid "Software Update"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:204
-msgid "Updates available"
+msgid "Updates Available"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:205
@@ -552,11 +552,11 @@ msgid "Software updates are available for your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:206
-msgid "Download now"
+msgid "Download Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:219
-msgid "Updates ready"
+msgid "Updates Ready"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:220
@@ -564,11 +564,11 @@ msgid "Software updates are ready to be installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:221
-msgid "Install now"
+msgid "Install Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:230
-msgid "Updates installed"
+msgid "Updates Installed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:231
@@ -576,11 +576,11 @@ msgid "Software updates were installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:232
-msgid "Restart now"
+msgid "Restart Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:255
-msgid "Update failed"
+msgid "Update Failed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:256

--- a/po/kn.po
+++ b/po/kn.po
@@ -545,7 +545,7 @@ msgid "Software Update"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:204
-msgid "Updates available"
+msgid "Updates Available"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:205
@@ -553,11 +553,11 @@ msgid "Software updates are available for your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:206
-msgid "Download now"
+msgid "Download Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:219
-msgid "Updates ready"
+msgid "Updates Ready"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:220
@@ -565,11 +565,11 @@ msgid "Software updates are ready to be installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:221
-msgid "Install now"
+msgid "Install Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:230
-msgid "Updates installed"
+msgid "Updates Installed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:231
@@ -577,11 +577,11 @@ msgid "Software updates were installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:232
-msgid "Restart now"
+msgid "Restart Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:255
-msgid "Update failed"
+msgid "Update Failed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:256

--- a/po/ko.po
+++ b/po/ko.po
@@ -546,7 +546,7 @@ msgid "Software Update"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:204
-msgid "Updates available"
+msgid "Updates Available"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:205
@@ -554,11 +554,11 @@ msgid "Software updates are available for your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:206
-msgid "Download now"
+msgid "Download Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:219
-msgid "Updates ready"
+msgid "Updates Ready"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:220
@@ -566,11 +566,11 @@ msgid "Software updates are ready to be installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:221
-msgid "Install now"
+msgid "Install Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:230
-msgid "Updates installed"
+msgid "Updates Installed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:231
@@ -578,11 +578,11 @@ msgid "Software updates were installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:232
-msgid "Restart now"
+msgid "Restart Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:255
-msgid "Update failed"
+msgid "Update Failed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:256

--- a/po/ku.po
+++ b/po/ku.po
@@ -546,7 +546,7 @@ msgid "Software Update"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:204
-msgid "Updates available"
+msgid "Updates Available"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:205
@@ -554,11 +554,11 @@ msgid "Software updates are available for your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:206
-msgid "Download now"
+msgid "Download Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:219
-msgid "Updates ready"
+msgid "Updates Ready"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:220
@@ -566,11 +566,11 @@ msgid "Software updates are ready to be installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:221
-msgid "Install now"
+msgid "Install Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:230
-msgid "Updates installed"
+msgid "Updates Installed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:231
@@ -578,11 +578,11 @@ msgid "Software updates were installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:232
-msgid "Restart now"
+msgid "Restart Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:255
-msgid "Update failed"
+msgid "Update Failed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:256

--- a/po/ky.po
+++ b/po/ky.po
@@ -546,7 +546,7 @@ msgid "Software Update"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:204
-msgid "Updates available"
+msgid "Updates Available"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:205
@@ -554,11 +554,11 @@ msgid "Software updates are available for your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:206
-msgid "Download now"
+msgid "Download Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:219
-msgid "Updates ready"
+msgid "Updates Ready"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:220
@@ -566,11 +566,11 @@ msgid "Software updates are ready to be installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:221
-msgid "Install now"
+msgid "Install Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:230
-msgid "Updates installed"
+msgid "Updates Installed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:231
@@ -578,11 +578,11 @@ msgid "Software updates were installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:232
-msgid "Restart now"
+msgid "Restart Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:255
-msgid "Update failed"
+msgid "Update Failed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:256

--- a/po/lt.po
+++ b/po/lt.po
@@ -548,7 +548,7 @@ msgid "Software Update"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:204
-msgid "Updates available"
+msgid "Updates Available"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:205
@@ -556,11 +556,11 @@ msgid "Software updates are available for your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:206
-msgid "Download now"
+msgid "Download Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:219
-msgid "Updates ready"
+msgid "Updates Ready"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:220
@@ -568,11 +568,11 @@ msgid "Software updates are ready to be installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:221
-msgid "Install now"
+msgid "Install Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:230
-msgid "Updates installed"
+msgid "Updates Installed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:231
@@ -580,11 +580,11 @@ msgid "Software updates were installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:232
-msgid "Restart now"
+msgid "Restart Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:255
-msgid "Update failed"
+msgid "Update Failed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:256

--- a/po/lv.po
+++ b/po/lv.po
@@ -548,7 +548,7 @@ msgid "Software Update"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:204
-msgid "Updates available"
+msgid "Updates Available"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:205
@@ -556,11 +556,11 @@ msgid "Software updates are available for your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:206
-msgid "Download now"
+msgid "Download Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:219
-msgid "Updates ready"
+msgid "Updates Ready"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:220
@@ -568,11 +568,11 @@ msgid "Software updates are ready to be installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:221
-msgid "Install now"
+msgid "Install Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:230
-msgid "Updates installed"
+msgid "Updates Installed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:231
@@ -580,11 +580,11 @@ msgid "Software updates were installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:232
-msgid "Restart now"
+msgid "Restart Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:255
-msgid "Update failed"
+msgid "Update Failed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:256

--- a/po/mk.po
+++ b/po/mk.po
@@ -544,7 +544,7 @@ msgid "Software Update"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:204
-msgid "Updates available"
+msgid "Updates Available"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:205
@@ -552,11 +552,11 @@ msgid "Software updates are available for your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:206
-msgid "Download now"
+msgid "Download Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:219
-msgid "Updates ready"
+msgid "Updates Ready"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:220
@@ -564,11 +564,11 @@ msgid "Software updates are ready to be installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:221
-msgid "Install now"
+msgid "Install Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:230
-msgid "Updates installed"
+msgid "Updates Installed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:231
@@ -576,11 +576,11 @@ msgid "Software updates were installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:232
-msgid "Restart now"
+msgid "Restart Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:255
-msgid "Update failed"
+msgid "Update Failed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:256

--- a/po/ml.po
+++ b/po/ml.po
@@ -548,7 +548,7 @@ msgid "Software Update"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:204
-msgid "Updates available"
+msgid "Updates Available"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:205
@@ -556,11 +556,11 @@ msgid "Software updates are available for your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:206
-msgid "Download now"
+msgid "Download Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:219
-msgid "Updates ready"
+msgid "Updates Ready"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:220
@@ -568,11 +568,11 @@ msgid "Software updates are ready to be installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:221
-msgid "Install now"
+msgid "Install Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:230
-msgid "Updates installed"
+msgid "Updates Installed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:231
@@ -580,11 +580,11 @@ msgid "Software updates were installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:232
-msgid "Restart now"
+msgid "Restart Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:255
-msgid "Update failed"
+msgid "Update Failed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:256

--- a/po/mr.po
+++ b/po/mr.po
@@ -546,7 +546,7 @@ msgid "Software Update"
 msgstr "सॉफ्टवेअर अद्यतन"
 
 #: ../js/ui/components/updaterManager.js:204
-msgid "Updates available"
+msgid "Updates Available"
 msgstr "अद्यतने उपलब्ध"
 
 #: ../js/ui/components/updaterManager.js:205
@@ -554,11 +554,11 @@ msgid "Software updates are available for your system"
 msgstr "आपल्या प्रणालीकरिता अद्यतने उपलब्ध आहेत"
 
 #: ../js/ui/components/updaterManager.js:206
-msgid "Download now"
+msgid "Download Now"
 msgstr "डाउनलोड करा"
 
 #: ../js/ui/components/updaterManager.js:219
-msgid "Updates ready"
+msgid "Updates Ready"
 msgstr "अद्यतने तयार"
 
 #: ../js/ui/components/updaterManager.js:220
@@ -566,11 +566,11 @@ msgid "Software updates are ready to be installed on your system"
 msgstr "सॉफ्टवेअर अद्यतने स्थापित करण्यासाठी तयार आहेत"
 
 #: ../js/ui/components/updaterManager.js:221
-msgid "Install now"
+msgid "Install Now"
 msgstr "स्थापित करा"
 
 #: ../js/ui/components/updaterManager.js:230
-msgid "Updates installed"
+msgid "Updates Installed"
 msgstr "अद्यतने स्थापित"
 
 #: ../js/ui/components/updaterManager.js:231
@@ -578,11 +578,11 @@ msgid "Software updates were installed on your system"
 msgstr "आपल्या प्रणालीवर सॉफ्टवेअर अद्यतने स्थापित करण्यात आली आहेत"
 
 #: ../js/ui/components/updaterManager.js:232
-msgid "Restart now"
+msgid "Restart Now"
 msgstr "पुन्हा चालू करा"
 
 #: ../js/ui/components/updaterManager.js:255
-msgid "Update failed"
+msgid "Update Failed"
 msgstr "अद्यतन अयशस्वी"
 
 #: ../js/ui/components/updaterManager.js:256

--- a/po/ms.po
+++ b/po/ms.po
@@ -545,7 +545,7 @@ msgid "Software Update"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:204
-msgid "Updates available"
+msgid "Updates Available"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:205
@@ -553,11 +553,11 @@ msgid "Software updates are available for your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:206
-msgid "Download now"
+msgid "Download Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:219
-msgid "Updates ready"
+msgid "Updates Ready"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:220
@@ -565,11 +565,11 @@ msgid "Software updates are ready to be installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:221
-msgid "Install now"
+msgid "Install Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:230
-msgid "Updates installed"
+msgid "Updates Installed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:231
@@ -577,11 +577,11 @@ msgid "Software updates were installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:232
-msgid "Restart now"
+msgid "Restart Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:255
-msgid "Update failed"
+msgid "Update Failed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:256

--- a/po/nb.po
+++ b/po/nb.po
@@ -545,7 +545,7 @@ msgid "Software Update"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:204
-msgid "Updates available"
+msgid "Updates Available"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:205
@@ -553,11 +553,11 @@ msgid "Software updates are available for your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:206
-msgid "Download now"
+msgid "Download Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:219
-msgid "Updates ready"
+msgid "Updates Ready"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:220
@@ -565,11 +565,11 @@ msgid "Software updates are ready to be installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:221
-msgid "Install now"
+msgid "Install Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:230
-msgid "Updates installed"
+msgid "Updates Installed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:231
@@ -577,11 +577,11 @@ msgid "Software updates were installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:232
-msgid "Restart now"
+msgid "Restart Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:255
-msgid "Update failed"
+msgid "Update Failed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:256

--- a/po/ne.po
+++ b/po/ne.po
@@ -544,7 +544,7 @@ msgid "Software Update"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:204
-msgid "Updates available"
+msgid "Updates Available"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:205
@@ -552,11 +552,11 @@ msgid "Software updates are available for your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:206
-msgid "Download now"
+msgid "Download Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:219
-msgid "Updates ready"
+msgid "Updates Ready"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:220
@@ -564,11 +564,11 @@ msgid "Software updates are ready to be installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:221
-msgid "Install now"
+msgid "Install Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:230
-msgid "Updates installed"
+msgid "Updates Installed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:231
@@ -576,11 +576,11 @@ msgid "Software updates were installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:232
-msgid "Restart now"
+msgid "Restart Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:255
-msgid "Update failed"
+msgid "Update Failed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:256

--- a/po/nl.po
+++ b/po/nl.po
@@ -548,7 +548,7 @@ msgid "Software Update"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:204
-msgid "Updates available"
+msgid "Updates Available"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:205
@@ -556,11 +556,11 @@ msgid "Software updates are available for your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:206
-msgid "Download now"
+msgid "Download Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:219
-msgid "Updates ready"
+msgid "Updates Ready"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:220
@@ -568,11 +568,11 @@ msgid "Software updates are ready to be installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:221
-msgid "Install now"
+msgid "Install Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:230
-msgid "Updates installed"
+msgid "Updates Installed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:231
@@ -580,11 +580,11 @@ msgid "Software updates were installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:232
-msgid "Restart now"
+msgid "Restart Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:255
-msgid "Update failed"
+msgid "Update Failed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:256

--- a/po/nn.po
+++ b/po/nn.po
@@ -549,7 +549,7 @@ msgid "Software Update"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:204
-msgid "Updates available"
+msgid "Updates Available"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:205
@@ -557,11 +557,11 @@ msgid "Software updates are available for your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:206
-msgid "Download now"
+msgid "Download Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:219
-msgid "Updates ready"
+msgid "Updates Ready"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:220
@@ -569,11 +569,11 @@ msgid "Software updates are ready to be installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:221
-msgid "Install now"
+msgid "Install Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:230
-msgid "Updates installed"
+msgid "Updates Installed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:231
@@ -581,11 +581,11 @@ msgid "Software updates were installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:232
-msgid "Restart now"
+msgid "Restart Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:255
-msgid "Update failed"
+msgid "Update Failed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:256

--- a/po/oc.po
+++ b/po/oc.po
@@ -546,7 +546,7 @@ msgid "Software Update"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:204
-msgid "Updates available"
+msgid "Updates Available"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:205
@@ -554,11 +554,11 @@ msgid "Software updates are available for your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:206
-msgid "Download now"
+msgid "Download Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:219
-msgid "Updates ready"
+msgid "Updates Ready"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:220
@@ -566,11 +566,11 @@ msgid "Software updates are ready to be installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:221
-msgid "Install now"
+msgid "Install Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:230
-msgid "Updates installed"
+msgid "Updates Installed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:231
@@ -578,11 +578,11 @@ msgid "Software updates were installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:232
-msgid "Restart now"
+msgid "Restart Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:255
-msgid "Update failed"
+msgid "Update Failed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:256

--- a/po/or.po
+++ b/po/or.po
@@ -545,7 +545,7 @@ msgid "Software Update"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:204
-msgid "Updates available"
+msgid "Updates Available"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:205
@@ -553,11 +553,11 @@ msgid "Software updates are available for your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:206
-msgid "Download now"
+msgid "Download Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:219
-msgid "Updates ready"
+msgid "Updates Ready"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:220
@@ -565,11 +565,11 @@ msgid "Software updates are ready to be installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:221
-msgid "Install now"
+msgid "Install Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:230
-msgid "Updates installed"
+msgid "Updates Installed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:231
@@ -577,11 +577,11 @@ msgid "Software updates were installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:232
-msgid "Restart now"
+msgid "Restart Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:255
-msgid "Update failed"
+msgid "Update Failed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:256

--- a/po/pa.po
+++ b/po/pa.po
@@ -545,7 +545,7 @@ msgid "Software Update"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:204
-msgid "Updates available"
+msgid "Updates Available"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:205
@@ -553,11 +553,11 @@ msgid "Software updates are available for your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:206
-msgid "Download now"
+msgid "Download Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:219
-msgid "Updates ready"
+msgid "Updates Ready"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:220
@@ -565,11 +565,11 @@ msgid "Software updates are ready to be installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:221
-msgid "Install now"
+msgid "Install Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:230
-msgid "Updates installed"
+msgid "Updates Installed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:231
@@ -577,11 +577,11 @@ msgid "Software updates were installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:232
-msgid "Restart now"
+msgid "Restart Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:255
-msgid "Update failed"
+msgid "Update Failed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:256

--- a/po/pl.po
+++ b/po/pl.po
@@ -546,7 +546,7 @@ msgid "Software Update"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:204
-msgid "Updates available"
+msgid "Updates Available"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:205
@@ -554,11 +554,11 @@ msgid "Software updates are available for your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:206
-msgid "Download now"
+msgid "Download Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:219
-msgid "Updates ready"
+msgid "Updates Ready"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:220
@@ -566,11 +566,11 @@ msgid "Software updates are ready to be installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:221
-msgid "Install now"
+msgid "Install Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:230
-msgid "Updates installed"
+msgid "Updates Installed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:231
@@ -578,11 +578,11 @@ msgid "Software updates were installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:232
-msgid "Restart now"
+msgid "Restart Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:255
-msgid "Update failed"
+msgid "Update Failed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:256

--- a/po/pt.po
+++ b/po/pt.po
@@ -567,7 +567,7 @@ msgid "Software Update"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:204
-msgid "Updates available"
+msgid "Updates Available"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:205
@@ -575,11 +575,11 @@ msgid "Software updates are available for your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:206
-msgid "Download now"
+msgid "Download Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:219
-msgid "Updates ready"
+msgid "Updates Ready"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:220
@@ -587,11 +587,11 @@ msgid "Software updates are ready to be installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:221
-msgid "Install now"
+msgid "Install Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:230
-msgid "Updates installed"
+msgid "Updates Installed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:231
@@ -599,11 +599,11 @@ msgid "Software updates were installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:232
-msgid "Restart now"
+msgid "Restart Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:255
-msgid "Update failed"
+msgid "Update Failed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:256

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -560,7 +560,7 @@ msgid "Software Update"
 msgstr "Atualização do Sistema"
 
 #: ../js/ui/components/updaterManager.js:204
-msgid "Updates available"
+msgid "Updates Available"
 msgstr "Atualizações disponíveis"
 
 #: ../js/ui/components/updaterManager.js:205
@@ -568,11 +568,11 @@ msgid "Software updates are available for your system"
 msgstr "Novas atualizações do software estão disponíveis para o seu sistema"
 
 #: ../js/ui/components/updaterManager.js:206
-msgid "Download now"
+msgid "Download Now"
 msgstr "Baixar agora"
 
 #: ../js/ui/components/updaterManager.js:219
-msgid "Updates ready"
+msgid "Updates Ready"
 msgstr "Atualizações prontas"
 
 #: ../js/ui/components/updaterManager.js:220
@@ -580,11 +580,11 @@ msgid "Software updates are ready to be installed on your system"
 msgstr "Novas atualizações do software disponíveis para serem instaladas no seu sistema"
 
 #: ../js/ui/components/updaterManager.js:221
-msgid "Install now"
+msgid "Install Now"
 msgstr "Instalar agora"
 
 #: ../js/ui/components/updaterManager.js:230
-msgid "Updates installed"
+msgid "Updates Installed"
 msgstr "Atualizações instaladas"
 
 #: ../js/ui/components/updaterManager.js:231
@@ -592,11 +592,11 @@ msgid "Software updates were installed on your system"
 msgstr "Novas atualizações do software foram instaladas no seu sistema"
 
 #: ../js/ui/components/updaterManager.js:232
-msgid "Restart now"
+msgid "Restart Now"
 msgstr "Reiniciar agora"
 
 #: ../js/ui/components/updaterManager.js:255
-msgid "Update failed"
+msgid "Update Failed"
 msgstr "Ocorreu um erro durante à atualização"
 
 #: ../js/ui/components/updaterManager.js:256

--- a/po/ro.po
+++ b/po/ro.po
@@ -552,7 +552,7 @@ msgid "Software Update"
 msgstr "Update soft"
 
 #: ../js/ui/components/updaterManager.js:204
-msgid "Updates available"
+msgid "Updates Available"
 msgstr "Sunt disponibile actualizari noi"
 
 #: ../js/ui/components/updaterManager.js:205
@@ -560,11 +560,11 @@ msgid "Software updates are available for your system"
 msgstr "Sunt disponibile actualizari pentru sistem"
 
 #: ../js/ui/components/updaterManager.js:206
-msgid "Download now"
+msgid "Download Now"
 msgstr "Descarca acum"
 
 #: ../js/ui/components/updaterManager.js:219
-msgid "Updates ready"
+msgid "Updates Ready"
 msgstr "Actualizari pregatite"
 
 #: ../js/ui/components/updaterManager.js:220
@@ -572,11 +572,11 @@ msgid "Software updates are ready to be installed on your system"
 msgstr "Actualizarile sunt pregatite pentru a fi instalate in sistem"
 
 #: ../js/ui/components/updaterManager.js:221
-msgid "Install now"
+msgid "Install Now"
 msgstr "Instaleaza acum"
 
 #: ../js/ui/components/updaterManager.js:230
-msgid "Updates installed"
+msgid "Updates Installed"
 msgstr "Actualizari instalate"
 
 #: ../js/ui/components/updaterManager.js:231
@@ -584,11 +584,11 @@ msgid "Software updates were installed on your system"
 msgstr "Actualizarile au fost instalate in sistem"
 
 #: ../js/ui/components/updaterManager.js:232
-msgid "Restart now"
+msgid "Restart Now"
 msgstr "Reporneste acum"
 
 #: ../js/ui/components/updaterManager.js:255
-msgid "Update failed"
+msgid "Update Failed"
 msgstr "Update esuat"
 
 #: ../js/ui/components/updaterManager.js:256

--- a/po/ru.po
+++ b/po/ru.po
@@ -555,7 +555,7 @@ msgid "Software Update"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:204
-msgid "Updates available"
+msgid "Updates Available"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:205
@@ -563,11 +563,11 @@ msgid "Software updates are available for your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:206
-msgid "Download now"
+msgid "Download Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:219
-msgid "Updates ready"
+msgid "Updates Ready"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:220
@@ -575,11 +575,11 @@ msgid "Software updates are ready to be installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:221
-msgid "Install now"
+msgid "Install Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:230
-msgid "Updates installed"
+msgid "Updates Installed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:231
@@ -587,11 +587,11 @@ msgid "Software updates were installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:232
-msgid "Restart now"
+msgid "Restart Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:255
-msgid "Update failed"
+msgid "Update Failed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:256

--- a/po/si.po
+++ b/po/si.po
@@ -545,7 +545,7 @@ msgid "Software Update"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:204
-msgid "Updates available"
+msgid "Updates Available"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:205
@@ -553,11 +553,11 @@ msgid "Software updates are available for your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:206
-msgid "Download now"
+msgid "Download Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:219
-msgid "Updates ready"
+msgid "Updates Ready"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:220
@@ -565,11 +565,11 @@ msgid "Software updates are ready to be installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:221
-msgid "Install now"
+msgid "Install Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:230
-msgid "Updates installed"
+msgid "Updates Installed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:231
@@ -577,11 +577,11 @@ msgid "Software updates were installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:232
-msgid "Restart now"
+msgid "Restart Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:255
-msgid "Update failed"
+msgid "Update Failed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:256

--- a/po/sk.po
+++ b/po/sk.po
@@ -547,7 +547,7 @@ msgid "Software Update"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:204
-msgid "Updates available"
+msgid "Updates Available"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:205
@@ -555,11 +555,11 @@ msgid "Software updates are available for your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:206
-msgid "Download now"
+msgid "Download Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:219
-msgid "Updates ready"
+msgid "Updates Ready"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:220
@@ -567,11 +567,11 @@ msgid "Software updates are ready to be installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:221
-msgid "Install now"
+msgid "Install Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:230
-msgid "Updates installed"
+msgid "Updates Installed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:231
@@ -579,11 +579,11 @@ msgid "Software updates were installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:232
-msgid "Restart now"
+msgid "Restart Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:255
-msgid "Update failed"
+msgid "Update Failed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:256

--- a/po/sl.po
+++ b/po/sl.po
@@ -544,7 +544,7 @@ msgid "Software Update"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:204
-msgid "Updates available"
+msgid "Updates Available"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:205
@@ -552,11 +552,11 @@ msgid "Software updates are available for your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:206
-msgid "Download now"
+msgid "Download Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:219
-msgid "Updates ready"
+msgid "Updates Ready"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:220
@@ -564,11 +564,11 @@ msgid "Software updates are ready to be installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:221
-msgid "Install now"
+msgid "Install Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:230
-msgid "Updates installed"
+msgid "Updates Installed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:231
@@ -576,11 +576,11 @@ msgid "Software updates were installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:232
-msgid "Restart now"
+msgid "Restart Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:255
-msgid "Update failed"
+msgid "Update Failed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:256

--- a/po/sr.po
+++ b/po/sr.po
@@ -547,7 +547,7 @@ msgid "Software Update"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:204
-msgid "Updates available"
+msgid "Updates Available"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:205
@@ -555,11 +555,11 @@ msgid "Software updates are available for your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:206
-msgid "Download now"
+msgid "Download Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:219
-msgid "Updates ready"
+msgid "Updates Ready"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:220
@@ -567,11 +567,11 @@ msgid "Software updates are ready to be installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:221
-msgid "Install now"
+msgid "Install Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:230
-msgid "Updates installed"
+msgid "Updates Installed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:231
@@ -579,11 +579,11 @@ msgid "Software updates were installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:232
-msgid "Restart now"
+msgid "Restart Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:255
-msgid "Update failed"
+msgid "Update Failed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:256

--- a/po/sr@latin.po
+++ b/po/sr@latin.po
@@ -547,7 +547,7 @@ msgid "Software Update"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:204
-msgid "Updates available"
+msgid "Updates Available"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:205
@@ -555,11 +555,11 @@ msgid "Software updates are available for your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:206
-msgid "Download now"
+msgid "Download Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:219
-msgid "Updates ready"
+msgid "Updates Ready"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:220
@@ -567,11 +567,11 @@ msgid "Software updates are ready to be installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:221
-msgid "Install now"
+msgid "Install Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:230
-msgid "Updates installed"
+msgid "Updates Installed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:231
@@ -579,11 +579,11 @@ msgid "Software updates were installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:232
-msgid "Restart now"
+msgid "Restart Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:255
-msgid "Update failed"
+msgid "Update Failed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:256

--- a/po/sv.po
+++ b/po/sv.po
@@ -549,7 +549,7 @@ msgid "Software Update"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:204
-msgid "Updates available"
+msgid "Updates Available"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:205
@@ -557,11 +557,11 @@ msgid "Software updates are available for your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:206
-msgid "Download now"
+msgid "Download Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:219
-msgid "Updates ready"
+msgid "Updates Ready"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:220
@@ -569,11 +569,11 @@ msgid "Software updates are ready to be installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:221
-msgid "Install now"
+msgid "Install Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:230
-msgid "Updates installed"
+msgid "Updates Installed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:231
@@ -581,11 +581,11 @@ msgid "Software updates were installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:232
-msgid "Restart now"
+msgid "Restart Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:255
-msgid "Update failed"
+msgid "Update Failed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:256

--- a/po/ta.po
+++ b/po/ta.po
@@ -546,7 +546,7 @@ msgid "Software Update"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:204
-msgid "Updates available"
+msgid "Updates Available"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:205
@@ -554,11 +554,11 @@ msgid "Software updates are available for your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:206
-msgid "Download now"
+msgid "Download Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:219
-msgid "Updates ready"
+msgid "Updates Ready"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:220
@@ -566,11 +566,11 @@ msgid "Software updates are ready to be installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:221
-msgid "Install now"
+msgid "Install Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:230
-msgid "Updates installed"
+msgid "Updates Installed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:231
@@ -578,11 +578,11 @@ msgid "Software updates were installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:232
-msgid "Restart now"
+msgid "Restart Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:255
-msgid "Update failed"
+msgid "Update Failed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:256

--- a/po/te.po
+++ b/po/te.po
@@ -548,7 +548,7 @@ msgid "Software Update"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:204
-msgid "Updates available"
+msgid "Updates Available"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:205
@@ -556,11 +556,11 @@ msgid "Software updates are available for your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:206
-msgid "Download now"
+msgid "Download Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:219
-msgid "Updates ready"
+msgid "Updates Ready"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:220
@@ -568,11 +568,11 @@ msgid "Software updates are ready to be installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:221
-msgid "Install now"
+msgid "Install Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:230
-msgid "Updates installed"
+msgid "Updates Installed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:231
@@ -580,11 +580,11 @@ msgid "Software updates were installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:232
-msgid "Restart now"
+msgid "Restart Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:255
-msgid "Update failed"
+msgid "Update Failed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:256

--- a/po/tg.po
+++ b/po/tg.po
@@ -545,7 +545,7 @@ msgid "Software Update"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:204
-msgid "Updates available"
+msgid "Updates Available"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:205
@@ -553,11 +553,11 @@ msgid "Software updates are available for your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:206
-msgid "Download now"
+msgid "Download Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:219
-msgid "Updates ready"
+msgid "Updates Ready"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:220
@@ -565,11 +565,11 @@ msgid "Software updates are ready to be installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:221
-msgid "Install now"
+msgid "Install Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:230
-msgid "Updates installed"
+msgid "Updates Installed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:231
@@ -577,11 +577,11 @@ msgid "Software updates were installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:232
-msgid "Restart now"
+msgid "Restart Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:255
-msgid "Update failed"
+msgid "Update Failed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:256

--- a/po/th.po
+++ b/po/th.po
@@ -548,7 +548,7 @@ msgid "Software Update"
 msgstr "อัปเดตซอฟท์แวร์"
 
 #: ../js/ui/components/updaterManager.js:204
-msgid "Updates available"
+msgid "Updates Available"
 msgstr "สามารถทำการอัปเดต"
 
 #: ../js/ui/components/updaterManager.js:205
@@ -556,11 +556,11 @@ msgid "Software updates are available for your system"
 msgstr "ระบบของคุณสามารถอัปเดตซอฟท์แวร์ได้"
 
 #: ../js/ui/components/updaterManager.js:206
-msgid "Download now"
+msgid "Download Now"
 msgstr "ดาวน์โหลดตอนนี้"
 
 #: ../js/ui/components/updaterManager.js:219
-msgid "Updates ready"
+msgid "Updates Ready"
 msgstr "พร้อมอัปเดต"
 
 #: ../js/ui/components/updaterManager.js:220
@@ -568,11 +568,11 @@ msgid "Software updates are ready to be installed on your system"
 msgstr "พร้อมที่จะติดตั้งอัปเดตซอฟท์แวร์ลงบนระบบของคุณ"
 
 #: ../js/ui/components/updaterManager.js:221
-msgid "Install now"
+msgid "Install Now"
 msgstr "ติดตั้งตอนนี้"
 
 #: ../js/ui/components/updaterManager.js:230
-msgid "Updates installed"
+msgid "Updates Installed"
 msgstr "ติดตั้งอัปเดตแล้ว"
 
 #: ../js/ui/components/updaterManager.js:231
@@ -580,11 +580,11 @@ msgid "Software updates were installed on your system"
 msgstr "ติดตั้งอัปเดตซอฟท์แวร์บนระบบของคุณแล้ว"
 
 #: ../js/ui/components/updaterManager.js:232
-msgid "Restart now"
+msgid "Restart Now"
 msgstr "เริ่มระบบใหม่ตอนนี้"
 
 #: ../js/ui/components/updaterManager.js:255
-msgid "Update failed"
+msgid "Update Failed"
 msgstr "อัปเดตล้มเหลว"
 
 #: ../js/ui/components/updaterManager.js:256

--- a/po/tr.po
+++ b/po/tr.po
@@ -554,7 +554,7 @@ msgid "Software Update"
 msgstr "Yazılım Güncelleme"
 
 #: ../js/ui/components/updaterManager.js:204
-msgid "Updates available"
+msgid "Updates Available"
 msgstr "Güncellemeler mevcut"
 
 #: ../js/ui/components/updaterManager.js:205
@@ -562,11 +562,11 @@ msgid "Software updates are available for your system"
 msgstr "Sisteminiz için yazılım güncellemeleri mevcut"
 
 #: ../js/ui/components/updaterManager.js:206
-msgid "Download now"
+msgid "Download Now"
 msgstr "İndir"
 
 #: ../js/ui/components/updaterManager.js:219
-msgid "Updates ready"
+msgid "Updates Ready"
 msgstr "Güncellemeler hazır"
 
 #: ../js/ui/components/updaterManager.js:220
@@ -574,11 +574,11 @@ msgid "Software updates are ready to be installed on your system"
 msgstr "Yazılım güncellemeleri kurulmak üzere hazır"
 
 #: ../js/ui/components/updaterManager.js:221
-msgid "Install now"
+msgid "Install Now"
 msgstr "Şimdi kur"
 
 #: ../js/ui/components/updaterManager.js:230
-msgid "Updates installed"
+msgid "Updates Installed"
 msgstr "Güncellemeler kuruldu"
 
 #: ../js/ui/components/updaterManager.js:231
@@ -586,11 +586,11 @@ msgid "Software updates were installed on your system"
 msgstr "Sisteminize yazılım güncellemeleri kuruldu"
 
 #: ../js/ui/components/updaterManager.js:232
-msgid "Restart now"
+msgid "Restart Now"
 msgstr "Yeniden Başlat"
 
 #: ../js/ui/components/updaterManager.js:255
-msgid "Update failed"
+msgid "Update Failed"
 msgstr "Güncelleme başarısız"
 
 #: ../js/ui/components/updaterManager.js:256

--- a/po/ug.po
+++ b/po/ug.po
@@ -547,7 +547,7 @@ msgid "Software Update"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:204
-msgid "Updates available"
+msgid "Updates Available"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:205
@@ -555,11 +555,11 @@ msgid "Software updates are available for your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:206
-msgid "Download now"
+msgid "Download Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:219
-msgid "Updates ready"
+msgid "Updates Ready"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:220
@@ -567,11 +567,11 @@ msgid "Software updates are ready to be installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:221
-msgid "Install now"
+msgid "Install Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:230
-msgid "Updates installed"
+msgid "Updates Installed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:231
@@ -579,11 +579,11 @@ msgid "Software updates were installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:232
-msgid "Restart now"
+msgid "Restart Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:255
-msgid "Update failed"
+msgid "Update Failed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:256

--- a/po/uk.po
+++ b/po/uk.po
@@ -548,7 +548,7 @@ msgid "Software Update"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:204
-msgid "Updates available"
+msgid "Updates Available"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:205
@@ -556,11 +556,11 @@ msgid "Software updates are available for your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:206
-msgid "Download now"
+msgid "Download Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:219
-msgid "Updates ready"
+msgid "Updates Ready"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:220
@@ -568,11 +568,11 @@ msgid "Software updates are ready to be installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:221
-msgid "Install now"
+msgid "Install Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:230
-msgid "Updates installed"
+msgid "Updates Installed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:231
@@ -580,11 +580,11 @@ msgid "Software updates were installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:232
-msgid "Restart now"
+msgid "Restart Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:255
-msgid "Update failed"
+msgid "Update Failed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:256

--- a/po/vi.po
+++ b/po/vi.po
@@ -549,7 +549,7 @@ msgid "Software Update"
 msgstr "Bản cập nhật Phần mềm"
 
 #: ../js/ui/components/updaterManager.js:204
-msgid "Updates available"
+msgid "Updates Available"
 msgstr "Bản cập nhật có sẵn"
 
 #: ../js/ui/components/updaterManager.js:205
@@ -557,11 +557,11 @@ msgid "Software updates are available for your system"
 msgstr "Đã có bản cập nhật phần mềm cho hệ thống của bạn"
 
 #: ../js/ui/components/updaterManager.js:206
-msgid "Download now"
+msgid "Download Now"
 msgstr "Tải xuống ngay"
 
 #: ../js/ui/components/updaterManager.js:219
-msgid "Updates ready"
+msgid "Updates Ready"
 msgstr "Bản cập nhật đã sẵn sàng"
 
 #: ../js/ui/components/updaterManager.js:220
@@ -569,11 +569,11 @@ msgid "Software updates are ready to be installed on your system"
 msgstr "Bản cập nhật phần mềm đã sẵn sàng để cài đặt vào hệ thống của bạn"
 
 #: ../js/ui/components/updaterManager.js:221
-msgid "Install now"
+msgid "Install Now"
 msgstr "Cài đặt ngay"
 
 #: ../js/ui/components/updaterManager.js:230
-msgid "Updates installed"
+msgid "Updates Installed"
 msgstr "Đã cài đặt bản cập nhật"
 
 #: ../js/ui/components/updaterManager.js:231
@@ -581,11 +581,11 @@ msgid "Software updates were installed on your system"
 msgstr "Bản cập nhật phần mềm đã được cài đặt vào hệ thống"
 
 #: ../js/ui/components/updaterManager.js:232
-msgid "Restart now"
+msgid "Restart Now"
 msgstr "Khởi động lại ngay"
 
 #: ../js/ui/components/updaterManager.js:255
-msgid "Update failed"
+msgid "Update Failed"
 msgstr "Cập nhật không thành công"
 
 #: ../js/ui/components/updaterManager.js:256

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -562,7 +562,7 @@ msgid "Software Update"
 msgstr "软件更新"
 
 #: ../js/ui/components/updaterManager.js:204
-msgid "Updates available"
+msgid "Updates Available"
 msgstr "可用的更新"
 
 #: ../js/ui/components/updaterManager.js:205
@@ -570,11 +570,11 @@ msgid "Software updates are available for your system"
 msgstr "有可用于您系统的软件更新"
 
 #: ../js/ui/components/updaterManager.js:206
-msgid "Download now"
+msgid "Download Now"
 msgstr "马上下载"
 
 #: ../js/ui/components/updaterManager.js:219
-msgid "Updates ready"
+msgid "Updates Ready"
 msgstr "更新已就绪"
 
 #: ../js/ui/components/updaterManager.js:220
@@ -582,11 +582,11 @@ msgid "Software updates are ready to be installed on your system"
 msgstr "软件更新已经准备好安装到您的系统"
 
 #: ../js/ui/components/updaterManager.js:221
-msgid "Install now"
+msgid "Install Now"
 msgstr "马上安装"
 
 #: ../js/ui/components/updaterManager.js:230
-msgid "Updates installed"
+msgid "Updates Installed"
 msgstr "更新完成"
 
 #: ../js/ui/components/updaterManager.js:231
@@ -594,11 +594,11 @@ msgid "Software updates were installed on your system"
 msgstr "软件更新已经安装到您的系统"
 
 #: ../js/ui/components/updaterManager.js:232
-msgid "Restart now"
+msgid "Restart Now"
 msgstr "马上重启"
 
 #: ../js/ui/components/updaterManager.js:255
-msgid "Update failed"
+msgid "Update Failed"
 msgstr "更新失败"
 
 #: ../js/ui/components/updaterManager.js:256

--- a/po/zh_HK.po
+++ b/po/zh_HK.po
@@ -546,7 +546,7 @@ msgid "Software Update"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:204
-msgid "Updates available"
+msgid "Updates Available"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:205
@@ -554,11 +554,11 @@ msgid "Software updates are available for your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:206
-msgid "Download now"
+msgid "Download Now"
 msgstr "下載"
 
 #: ../js/ui/components/updaterManager.js:219
-msgid "Updates ready"
+msgid "Updates Ready"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:220
@@ -566,11 +566,11 @@ msgid "Software updates are ready to be installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:221
-msgid "Install now"
+msgid "Install Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:230
-msgid "Updates installed"
+msgid "Updates Installed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:231
@@ -578,11 +578,11 @@ msgid "Software updates were installed on your system"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:232
-msgid "Restart now"
+msgid "Restart Now"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:255
-msgid "Update failed"
+msgid "Update Failed"
 msgstr ""
 
 #: ../js/ui/components/updaterManager.js:256

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -546,7 +546,7 @@ msgid "Software Update"
 msgstr "軟體更新"
 
 #: ../js/ui/components/updaterManager.js:204
-msgid "Updates available"
+msgid "Updates Available"
 msgstr "有可取得的更新"
 
 #: ../js/ui/components/updaterManager.js:205
@@ -554,11 +554,11 @@ msgid "Software updates are available for your system"
 msgstr "有軟體更新可供系統使用"
 
 #: ../js/ui/components/updaterManager.js:206
-msgid "Download now"
+msgid "Download Now"
 msgstr "下載"
 
 #: ../js/ui/components/updaterManager.js:219
-msgid "Updates ready"
+msgid "Updates Ready"
 msgstr "更新準備完畢"
 
 #: ../js/ui/components/updaterManager.js:220
@@ -566,11 +566,11 @@ msgid "Software updates are ready to be installed on your system"
 msgstr "軟體更新已經準備好要安裝在你的系統上"
 
 #: ../js/ui/components/updaterManager.js:221
-msgid "Install now"
+msgid "Install Now"
 msgstr "現在安裝"
 
 #: ../js/ui/components/updaterManager.js:230
-msgid "Updates installed"
+msgid "Updates Installed"
 msgstr "更新安裝完畢"
 
 #: ../js/ui/components/updaterManager.js:231
@@ -578,11 +578,11 @@ msgid "Software updates were installed on your system"
 msgstr "軟體更新已安裝在你的系統中"
 
 #: ../js/ui/components/updaterManager.js:232
-msgid "Restart now"
+msgid "Restart Now"
 msgstr "立即重新開始"
 
 #: ../js/ui/components/updaterManager.js:255
-msgid "Update failed"
+msgid "Update Failed"
 msgstr "更新失敗"
 
 #: ../js/ui/components/updaterManager.js:256


### PR DESCRIPTION
The buttons and titles of the updater notifications should be in title
case, according to the GNOME HIG:

https://developer.gnome.org/hig/unstable/writing-style.html.en#capitalization

This includes changes to the .pot and .po files to ensure the relevant
strings do not need to be re-translated, since the capitalisation rules
for English don’t commonly apply in other locales.

Signed-off-by: Philip Withnall <withnall@endlessm.com>

https://phabricator.endlessm.com/T15644