### PR TITLE
Update background color

### DIFF
--- a/data/theme/gnome-shell.css
+++ b/data/theme/gnome-shell.css
@@ -2988,7 +2988,7 @@ StScrollBar StButton#vhandle:active {
 }
 
 #lockDialogGroup {
-    background: #2e3436 url(noise-texture.png);
+    background: #12282e url(noise-texture.png);
     background-repeat: repeat;
 }
 

--- a/js/ui/background.js
+++ b/js/ui/background.js
@@ -108,7 +108,7 @@ const Params = imports.misc.params;
 const Tweener = imports.ui.tweener;
 const Util = imports.misc.util;
 
-const DEFAULT_BACKGROUND_COLOR = Clutter.Color.from_pixel(0x2e3436ff);
+const DEFAULT_BACKGROUND_COLOR = Clutter.Color.from_pixel(0x12282eff);
 
 const BACKGROUND_SCHEMA = 'org.gnome.desktop.background';
 const PRIMARY_COLOR_KEY = 'primary-color';


### PR DESCRIPTION
Use a darker, more blue color to match the new plymouth theme
for startup and shutdown screens.

https://phabricator.endlessm.com/T15693