### PR TITLE
messageTray: Reset clickedSummaryItem on ungrab

### DIFF
--- a/js/ui/messageTray.js
+++ b/js/ui/messageTray.js
@@ -2877,6 +2877,7 @@ const MessageTray = new Lang.Class({
 
     _onSummaryBoxPointerUngrabbed: function() {
         this._summaryBoxPointerState = State.HIDING;
+        this._setClickedSummaryItem(null);
 
         if (this._summaryBoxPointerContentUpdatedId) {
             this._summaryBoxPointerItem.disconnect(this._summaryBoxPointerContentUpdatedId);


### PR DESCRIPTION
If we don't, we will pop up the summary again the next time
_updateState() is called.

https://bugzilla.gnome.org/show_bug.cgi?id=707600

https://phabricator.endlessm.com/T15855