### PR TITLE
searchEntry: fix vertical placement

### DIFF
--- a/data/theme/gnome-shell.css
+++ b/data/theme/gnome-shell.css
@@ -982,7 +982,7 @@ StScrollBar StButton#vhandle:active {
     width: 300px;
     height: 38px;
 
-    margin-top: 2px;
+    margin-top: 8px;
     padding: 0 12px 0 0;
 
     font-family: lato, sans-serif;


### PR DESCRIPTION
The search entry is 6px misaligned (again). Fix that by increasing
the margin-top CSS property.

https://phabricator.endlessm.com/T15536