### PR TITLE
coding: Track button to either app or builder window

### DIFF
--- a/js/ui/codingManager.js
+++ b/js/ui/codingManager.js
@@ -230,11 +230,11 @@ const WindowTrackingButton = new Lang.Class({
     track: function(window) {
         // Untrack the current window and track the newly specified one.
         if (this._positionChangedId) {
-            this._trackingWindow.disconnect(this.positionChangedId);
+            this._trackingWindow.disconnect(this._positionChangedId);
         }
 
         if (this._sizeChangedId) {
-            this._trackingWindow.disconnect(this.sizeChangedId);
+            this._trackingWindow.disconnect(this._sizeChangedId);
         }
 
         this._trackingWindow = window;


### PR DESCRIPTION
Instead of just tracking the app window. This means that we don't
have to wait for a round-trip until the app window gets resized.

https://phabricator.endlessm.com/T15944