### PR TITLE
Add a DBus method to add an app only if it's not visible

### DIFF
--- a/js/ui/shellDBus.js
+++ b/js/ui/shellDBus.js
@@ -457,6 +457,9 @@ const AppStoreIface = '<node> \
 <method name="AddApplication"> \
     <arg type="s" direction="in" name="id" /> \
 </method> \
+<method name="AddAppIfNotVisible"> \
+    <arg type="s" direction="in" name="id" /> \
+</method> \
 <method name="RemoveApplication"> \
     <arg type="s" direction="in" name="id" /> \
 </method> \
@@ -493,6 +496,21 @@ const AppStoreService = new Lang.Class({
         eventRecorder.record_event(SHELL_APP_ADDED_EVENT, appId);
 
         if (!IconGridLayout.layout.iconIsFolder(id)) {
+            IconGridLayout.layout.appendIcon(id, IconGridLayout.DESKTOP_GRID_ID);
+        }
+    },
+
+    AddAppIfNotVisible: function(id) {
+        let eventRecorder = EosMetrics.EventRecorder.get_default();
+        let appId = new GLib.Variant('s', id);
+        eventRecorder.record_event(SHELL_APP_ADDED_EVENT, appId);
+
+        if (IconGridLayout.layout.iconIsFolder(id)) {
+            return;
+        }
+
+        let visibleIcons = IconGridLayout.layout.getIcons(IconGridLayout.DESKTOP_GRID_ID);
+        if (visibleIcons.indexOf(id) == -1) {
             IconGridLayout.layout.appendIcon(id, IconGridLayout.DESKTOP_GRID_ID);
         }
     },


### PR DESCRIPTION
Sometimes we need to make sure an application is visible in the
desktop's grid (i.e. in its top level folder) but without forcing
an append of its icon because if the app is already visible it should
not move to the end of the grid.
For that reason a new AddAppIfNotVisible method is added to the DBus
interface which will only add the given app to the desktop if it's not
already there and visible.

https://phabricator.endlessm.com/T15941