### PR TITLE
searchEntry: fix white spinner

### DIFF
--- a/data/gnome-shell-theme.gresource.xml
+++ b/data/gnome-shell-theme.gresource.xml
@@ -42,6 +42,7 @@
     <file>panel-button-highlight-narrow.svg</file>
     <file>panel-button-highlight-wide.svg</file>
     <file>process-working.svg</file>
+    <file>process-working-dark.svg</file>
     <file>rotate.svg</file>
     <file>running-indicator.svg</file>
     <file>settings-hover.png</file>

--- a/data/theme/process-working-dark.svg
+++ b/data/theme/process-working-dark.svg
@@ -1,0 +1,261 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg5369"
+   version="1.1"
+   inkscape:version="0.48+devel r10053 custom"
+   width="96"
+   height="48"
+   sodipodi:docname="process-working.svg"
+   style="display:inline">
+  <metadata
+     id="metadata5375">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs5373" />
+  <sodipodi:namedview
+     pagecolor="#808080"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1975"
+     inkscape:window-height="1098"
+     id="namedview5371"
+     showgrid="true"
+     borderlayer="true"
+     inkscape:showpageshadow="false"
+     inkscape:zoom="16"
+     inkscape:cx="53.997662"
+     inkscape:cy="22.367695"
+     inkscape:window-x="1600"
+     inkscape:window-y="33"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="layer2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid11933"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <g
+     inkscape:groupmode="layer"
+     id="layer1"
+     inkscape:label="tiles"
+     style="display:none">
+    <rect
+       style="color:#000000;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="rect12451"
+       width="24"
+       height="24"
+       x="0"
+       y="0" />
+    <rect
+       y="24"
+       x="0"
+       height="24"
+       width="24"
+       id="rect12453"
+       style="color:#000000;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    <rect
+       y="0"
+       x="24"
+       height="24"
+       width="24"
+       id="rect12455"
+       style="color:#000000;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    <rect
+       style="color:#000000;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="rect12457"
+       width="24"
+       height="24"
+       x="24"
+       y="24" />
+    <rect
+       style="color:#000000;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="rect12459"
+       width="24"
+       height="24"
+       x="48"
+       y="0" />
+    <rect
+       y="24"
+       x="48"
+       height="24"
+       width="24"
+       id="rect12461"
+       style="color:#000000;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    <rect
+       y="0"
+       x="72"
+       height="24"
+       width="24"
+       id="rect12463"
+       style="color:#000000;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    <rect
+       style="color:#000000;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="rect12465"
+       width="24"
+       height="24"
+       x="72"
+       y="24" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="spinner">
+    <g
+       transform="matrix(0.28240106,0,0,0.28240106,146.92015,-382.52444)"
+       id="g10450-5"
+       style="display:inline">
+      <path
+         inkscape:connector-curvature="0"
+         style="opacity:0.6;color:#000000;fill:none;stroke:#333333;stroke-width:7.08212566;stroke-linecap:round;stroke-opacity:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         d="m -477.76072,1373.3569 0,9.4717"
+         id="path18768"
+         sodipodi:nodetypes="cc"
+         inkscape:transform-center-y="-4.6808838" />
+      <path
+         inkscape:connector-curvature="0"
+         inkscape:transform-center-y="-3.3099227"
+         sodipodi:nodetypes="cc"
+         id="path18770"
+         d="m -461.0171,1380.2922 -7.23427,7.3824"
+         style="opacity:0.7;color:#000000;fill:none;stroke:#333333;stroke-width:7.08212566;stroke-linecap:round;stroke-opacity:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         inkscape:transform-center-x="-3.3098966" />
+      <path
+         inkscape:connector-curvature="0"
+         inkscape:transform-center-x="-4.6808962"
+         style="opacity:0.8;color:#000000;fill:none;stroke:#333333;stroke-width:7.08212566;stroke-linecap:round;stroke-opacity:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         d="m -454.08163,1397.0359 -9.47165,0"
+         id="path18772"
+         sodipodi:nodetypes="cc"
+         inkscape:transform-center-y="-2.6596956e-05" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc"
+         id="path18774"
+         d="m -461.01709,1413.7796 -6.93831,-7.0864"
+         style="opacity:0.9;color:#000000;fill:none;stroke:#333333;stroke-width:7.08212566;stroke-linecap:round;stroke-opacity:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         inkscape:transform-center-x="-3.3098966"
+         inkscape:transform-center-y="3.3098652" />
+      <path
+         inkscape:connector-curvature="0"
+         inkscape:transform-center-y="4.6808757"
+         style="color:#000000;fill:none;stroke:#333333;stroke-width:7.08212566;stroke-linecap:round;stroke-opacity:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         d="m -477.76074,1420.715 9e-5,-9.4716"
+         id="path18776"
+         sodipodi:nodetypes="cc" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc"
+         id="path18778"
+         d="m -494.50442,1413.7796 6.79048,-6.9384"
+         style="opacity:0.3;color:#000000;fill:none;stroke:#333333;stroke-width:7.08212566;stroke-linecap:round;stroke-opacity:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         inkscape:transform-center-y="3.3098769"
+         inkscape:transform-center-x="3.3098883" />
+      <path
+         inkscape:connector-curvature="0"
+         inkscape:transform-center-x="4.6808941"
+         style="opacity:0.4;color:#000000;fill:none;stroke:#333333;stroke-width:7.08212566;stroke-linecap:round;stroke-opacity:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         d="m -501.43987,1397.0359 9.47174,0"
+         id="path18780"
+         sodipodi:nodetypes="cc"
+         inkscape:transform-center-y="-2.6596956e-05" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc"
+         id="path18782"
+         d="m -494.5044,1380.2922 6.64243,6.9384"
+         style="opacity:0.5;color:#000000;fill:none;stroke:#333333;stroke-width:7.08212566;stroke-linecap:round;stroke-opacity:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+         inkscape:transform-center-x="3.3098902"
+         inkscape:transform-center-y="-3.3099302" />
+    </g>
+    <use
+       style="display:inline"
+       x="0"
+       y="0"
+       xlink:href="#g10450-5"
+       id="use4981"
+       transform="matrix(0.70710678,0.70710678,-0.70710678,0.70710678,36,-4.9705636)"
+       width="400"
+       height="400" />
+    <use
+       style="display:inline"
+       x="0"
+       y="0"
+       xlink:href="#use4981"
+       id="use4983"
+       transform="matrix(0.70710678,0.70710678,-0.70710678,0.70710678,43.032478,-21.909695)"
+       width="400"
+       height="400" />
+    <use
+       style="display:inline"
+       x="0"
+       y="0"
+       xlink:href="#use4983"
+       id="use4985"
+       transform="matrix(0.70710678,0.70710678,-0.70710678,0.70710678,50.081986,-38.904617)"
+       width="400"
+       height="400" />
+    <use
+       style="display:inline"
+       x="0"
+       y="0"
+       xlink:href="#use4985"
+       id="use4987"
+       transform="matrix(0.70710678,0.70710678,-0.70710678,0.70710678,-38.919996,-31.872139)"
+       width="400"
+       height="400" />
+    <use
+       style="display:inline"
+       x="0"
+       y="0"
+       xlink:href="#use4987"
+       id="use4989"
+       transform="matrix(0.70710678,0.70710678,-0.70710678,0.70710678,52.986628,2.0890543)"
+       width="400"
+       height="400" />
+    <use
+       style="display:inline"
+       x="0"
+       y="0"
+       xlink:href="#use4989"
+       id="use4991"
+       transform="matrix(0.70710678,0.70710678,-0.70710678,0.70710678,60.013026,-14.912936)"
+       width="400"
+       height="400" />
+    <use
+       style="display:inline"
+       x="0"
+       y="0"
+       xlink:href="#use4991"
+       id="use4993"
+       transform="matrix(0.70710678,0.70710678,-0.70710678,0.70710678,67.022396,-31.859127)"
+       width="400"
+       height="400" />
+  </g>
+</svg>

--- a/js/ui/shellEntry.js
+++ b/js/ui/shellEntry.js
@@ -175,7 +175,7 @@ const OverviewEntry = new Lang.Class({
                                         icon_size: 16,
                                         track_hover: true });
 
-        this._spinnerAnimation = new Panel.AnimatedIcon('process-working.svg', SPINNER_ICON_SIZE);
+        this._spinnerAnimation = new Panel.AnimatedIcon('process-working-dark.svg', SPINNER_ICON_SIZE);
         this._spinnerAnimation.actor.hide();
 
         // Set the search entry's text based on the current search engine


### PR DESCRIPTION
After the introduction of the new searchbar style,
the spinner became almost invisible since it's white
over the new white background.

Fix that by adding a new dark spinner, and using it
on the desktop search bar.

https://phabricator.endlessm.com/T15536