### PR TITLE
CodeView: Report underlying events on CodingSession to interested parties

### DIFF
--- a/js/ui/codingManager.js
+++ b/js/ui/codingManager.js
@@ -1222,7 +1222,6 @@ const CodeViewManager = new Lang.Class({
 
         // Destroy the session here and remove it from the list
         session.destroy();
-        this._disconnectFlatpakMonitor();
 
         let idx = this._sessions.indexOf(session);
         if (idx != -1) {

--- a/js/ui/codingManager.js
+++ b/js/ui/codingManager.js
@@ -12,7 +12,6 @@ const Mainloop = imports.mainloop;
 const Meta = imports.gi.Meta;
 const Shell = imports.gi.Shell;
 const St = imports.gi.St;
-const IconGridLayout = imports.ui.iconGridLayout;
 
 const AppActivation = imports.ui.appActivation;
 const Main = imports.ui.main;
@@ -1076,6 +1075,7 @@ const CodingOSIntegration = new Lang.Class({
                 }
             }));
 
+            session.connect('closed', Lang.bind(this, function() {
                 if (listeningFor.has('codeview-closed')) {
                     listeningFor.delete('codeview-closed');
                     controller.event_occurred('codeview-closed');

--- a/js/ui/codingManager.js
+++ b/js/ui/codingManager.js
@@ -467,6 +467,14 @@ const CodingSession = new Lang.Class({
                                                     GObject.ParamFlags.CONSTRUCT_ONLY,
                                                     CodingInstallationMonitor.$gtype)
     },
+    Signals: {
+        'opened': {},
+        'ready': {},
+        'closed': {},
+        'flipped': {
+            param_types: [ GObject.TYPE_INT ]
+        }
+    },
 
     _init: function(params) {
         this.parent(params);
@@ -534,6 +542,7 @@ const CodingSession = new Lang.Class({
             // We also only want to hide the speedwagon window at this
             // point, since the other window has arrived.
             this.splash.rampOut();
+            this.emit('ready');
         }
 
         // Now, if we're not already on the builder window, we want to start
@@ -560,6 +569,7 @@ const CodingSession = new Lang.Class({
                                  this.builder,
                                  Gtk.DirectionType.LEFT);
             this._state = STATE_BUILDER;
+            this.emit('flipped', this._state);
         }
 
         return true;
@@ -585,9 +595,11 @@ const CodingSession = new Lang.Class({
         this.button.builder_window = null;
         this.builder = null;
         this._state = STATE_APP;
+        this.emit('flipped', this._state);
 
         this.app.meta_window.activate(global.get_current_time());
         this.app.show();
+        this.emit('closed');
     },
 
     // Eject out of this session and remove all pairings.
@@ -642,6 +654,7 @@ const CodingSession = new Lang.Class({
 
             this.builder.meta_window.activate(global.get_current_time());
             this.builder.show();
+            this.emit('closed');
 
             // Note that we do not set this._state to STATE_APP here. Any
             // further usage of this session is undefined and it should
@@ -734,6 +747,7 @@ const CodingSession = new Lang.Class({
                           Gtk.DirectionType.LEFT);
             this.button.switchAnimation(Gtk.DirectionType.LEFT);
             this._state = STATE_BUILDER;
+            this.emit('flipped', this._state);
         }
     },
 
@@ -747,6 +761,7 @@ const CodingSession = new Lang.Class({
                       Gtk.DirectionType.RIGHT);
         this.button.switchAnimation(Gtk.DirectionType.RIGHT);
         this._state = STATE_APP;
+        this.emit('flipped', this._state);
     },
 
     // Given some recently-focused actor, switch to it without
@@ -781,6 +796,7 @@ const CodingSession = new Lang.Class({
         }
 
         actor.meta_window.activate(global.get_current_time());
+        this.emit('flipped', this._state);
     },
 
     // Assuming that we are only listening to some signal on app and builder,

--- a/js/ui/codingManager.js
+++ b/js/ui/codingManager.js
@@ -387,7 +387,7 @@ const CodingInstallationMonitor = new Lang.Class({
 
         let apps = userInstallation.list_installed_refs_by_kind(Flatpak.RefKind.APP, null);
         for (let i = 0; i < apps.length; i++) {
-            if (apps[i].name === params.app_name) {
+            if (apps[i].name === params.flatpak_name) {
                 this._commit = apps[i].commit;
                 break;
             }
@@ -1186,7 +1186,7 @@ const CodeViewManager = new Lang.Class({
             })
         });
         this._sessions.push(session);
-        log("Session created");
+
         this.emit('session-created', session);
         return true;
     },

--- a/js/ui/codingManager.js
+++ b/js/ui/codingManager.js
@@ -382,6 +382,7 @@ const CodingInstallationMonitor = new Lang.Class({
 
     _init: function(params) {
         this.parent(params);
+        this._changed = false;
 
         let userInstallation = Flatpak.Installation.new_user(null);
 
@@ -414,6 +415,7 @@ const CodingInstallationMonitor = new Lang.Class({
                     return;
 
                 this._commit = app.commit;
+                this._changed = true;
                 this.emit('app-installed');
 
                 this.disconnect();
@@ -430,7 +432,7 @@ const CodingInstallationMonitor = new Lang.Class({
     },
 
     get installed() {
-        return this._commit !== 0;
+        return this._changed;
     }
 });
 

--- a/js/ui/codingManager.js
+++ b/js/ui/codingManager.js
@@ -416,9 +416,6 @@ const CodingInstallationMonitor = new Lang.Class({
                 this._commit = app.commit;
                 this.emit('app-installed');
 
-                if (this._codeViewInstalled)
-                    this._controller.event_occurred('codeview-installed');
-
                 this.disconnect();
             })
         );

--- a/js/ui/codingManager.js
+++ b/js/ui/codingManager.js
@@ -468,7 +468,6 @@ const CodingSession = new Lang.Class({
                                                     CodingInstallationMonitor.$gtype)
     },
     Signals: {
-        'opened': {},
         'ready': {},
         'closed': {},
         'flipped': {

--- a/js/ui/codingManager.js
+++ b/js/ui/codingManager.js
@@ -208,6 +208,7 @@ const WindowTrackingButton = new Lang.Class({
             this.emit('clicked');
         }));
 
+<<<<<<< HEAD
         // Connect to signals on the window to determine when to move
         // hide, and show the button. Note that WindowTrackingButton is
         // constructed with the primary app window and we listen for signals
@@ -235,6 +236,14 @@ const WindowTrackingButton = new Lang.Class({
         this._windowUnminimizedId = global.window_manager.connect(
             'unminimize', Lang.bind(this, this._show)
         );
+=======
+        this._addSwitcherToBuilder(actor);
+
+        if (this._codeViewStarted) {
+            this._controller.event_occurred('codeview-started');
+            this._codeViewStarted = false;
+        }
+>>>>>>> CodeView: listen as well for codeview-started and codeview-flipped
     },
 
     // Users MUST call destroy before unreferencing this button - this will
@@ -266,10 +275,22 @@ const WindowTrackingButton = new Lang.Class({
             this._overviewHidingId = 0;
         }
 
+<<<<<<< HEAD
         if (this._windowMinimizedId) {
             global.window_manager.disconnect(this._windowMinimizedId);
             this._windowMinimizedId = 0;
         }
+=======
+        this._addSwitcherToApp(actor, session);
+
+        if (this._codeViewFlipped) {
+            this._controller.event_occurred('codeview-flipped');
+            this._codeViewFlipped = false;
+        }
+
+        return true;
+    },
+>>>>>>> CodeView: listen as well for codeview-started and codeview-flipped
 
         if (this._windowUnminimizedId) {
             global.window_manager.disconnect(this._windowUnminimizedId);
@@ -938,6 +959,8 @@ const CodingManager = new Lang.Class({
 
         this._flatpakMonitorId = 0;
         this._commit = 0;
+        this._codeViewFlipped = false;
+        this._codeViewStarted = false;
         this._controller = this._createAppIntegrationController();
     },
 
@@ -1032,6 +1055,16 @@ const CodingManager = new Lang.Class({
 
     _createAppIntegrationController: function() {
         let controller = new CodingGameService.AppIntegrationController();
+        controller.service_event_with_listener('codeview-started', Lang.bind(this, function() {
+            this._codeViewStarted = true;
+        }), Lang.bind(this, function() {
+            this._codeViewStarted = false;
+        }));
+        controller.service_event_with_listener('codeview-flipped', Lang.bind(this, function() {
+            this._codeViewFlipped = true;
+        }), Lang.bind(this, function() {
+            this._codeViewFlipped = false;
+        }));
         controller.service_event_with_listener('codeview-installed', Lang.bind(this, function() {
             this._connectFlatpakMonitor();
         }), Lang.bind(this, function() {

--- a/js/ui/codingManager.js
+++ b/js/ui/codingManager.js
@@ -1,6 +1,7 @@
 // -*- mode: js; js-indent-level: 4; indent-tabs-mode: nil -*-
 
 const Clutter = imports.gi.Clutter;
+const CodingGameService = imports.gi.CodingGameService;
 const Flatpak = imports.gi.Flatpak;
 const Gio = imports.gi.Gio;
 const GLib = imports.gi.GLib;
@@ -932,6 +933,12 @@ const CodingManager = new Lang.Class({
 
     _init: function() {
         this._sessions = [];
+
+        this._codingApps = ['com.endlessm.Helloworld', 'org.gnome.Weather.Application'];
+
+        this._flatpakMonitorId = 0;
+        this._commit = 0;
+        this._controller = this._createAppIntegrationController();
     },
 
     addAppWindow: function(actor) {
@@ -1022,4 +1029,62 @@ const CodingManager = new Lang.Class({
 
         return null;
     }
+
+    _createAppIntegrationController: function() {
+        let controller = new CodingGameService.AppIntegrationController();
+        controller.service_event_with_listener('codeview-installed', Lang.bind(this, function() {
+            this._connectFlatpakMonitor();
+        }), Lang.bind(this, function() {
+            this._disconnectFlatpakMonitor();
+        }));
+        return controller;
+    },
+
+    _connectFlatpakMonitor: function() {
+        let userInstallation = Flatpak.Installation.new_user(null);
+
+        let apps = userInstallation.list_installed_refs_by_kind(Flatpak.RefKind.APP, null);
+        for (let i = 0; i < apps.length; i++) {
+            if (apps[i].name === 'org.gnome.Weather.Application') {
+                this._commit = apps[i].commit;
+                break;
+            }
+        }
+
+        this._flatpakMonitor = userInstallation.create_monitor(null);
+        this._flatpakMonitorId = this._flatpakMonitor.connect('changed',
+            Lang.bind(this, function(monitor, file, other, type) {
+                // we are monitoring a file .changed which
+                // gets deleted and created on every change independent
+                // of install or uninstall, therefore only track the done hint
+                if (type === Gio.FileMonitorEvent.CHANGES_DONE_HINT) {
+                    let app;
+                    try {
+                        let userInstallation = Flatpak.Installation.new_user(null);
+                        app = userInstallation.get_current_installed_app('org.gnome.Weather.Application', null);
+                    } catch(e) {
+                        // application not installed or just got deleted
+                        return;
+                    }
+
+                    if (app.commit === this._commit)
+                      return;
+
+                    this._commit = app.commit;
+                    this._controller.event_occurred('codeview-installed');
+                    this._disconnectFlatpakMonitor();
+                }
+        }));
+    },
+
+    _disconnectFlatpakMonitor: function() {
+        if (this._flatpakMonitorId) {
+            this._flatpakMonitor.disconnect(this._flatpakMonitorId);
+            this._flatpakMonitorId = 0;
+        }
+    },
+
+    _isCodingApp: function(flatpakID) {
+        return this._codingApps.indexOf(flatpakID) != -1;
+    },
 });

--- a/js/ui/codingManager.js
+++ b/js/ui/codingManager.js
@@ -475,6 +475,10 @@ const CodingSession = new Lang.Class({
         }
     },
 
+    get state() {
+        return this._state;
+    },
+
     _init: function(params) {
         this.parent(params);
 

--- a/js/ui/codingManager.js
+++ b/js/ui/codingManager.js
@@ -1103,7 +1103,7 @@ const CodingOSIntegration = new Lang.Class({
             // session open
             if (manager.sessions.some(s =>
                     s.app.meta_window.get_flatpak_id() === OS_INTEGRATION_APP &&
-                    s.builder !== NULL
+                    s.builder !== null
             )) {
                 controller.event_occurred('codeview-started');
                 return;

--- a/js/ui/codingManager.js
+++ b/js/ui/codingManager.js
@@ -404,7 +404,7 @@ const CodingInstallationMonitor = new Lang.Class({
 
                 let app;
                 try {
-                    app = userInstallation.get_current_installed_app(this.app_name, null);
+                    app = userInstallation.get_current_installed_app(this.flatpak_name, null);
                 } catch(e) {
                     // application not installed or just got deleted
                     return;

--- a/js/ui/tweener.js
+++ b/js/ui/tweener.js
@@ -53,8 +53,8 @@ function _wrapTweening(target, tweeningParameters) {
         }
     }
 
-    //if (!Gtk.Settings.get_default().gtk_enable_animations)
-    //    tweeningParameters['time'] = 0.000001;
+    if (!Gtk.Settings.get_default().gtk_enable_animations)
+        tweeningParameters['time'] = 0.000001;
 
     _addHandler(target, tweeningParameters, 'onComplete', _tweenCompleted);
 }

--- a/js/ui/tweener.js
+++ b/js/ui/tweener.js
@@ -53,8 +53,8 @@ function _wrapTweening(target, tweeningParameters) {
         }
     }
 
-    if (!Gtk.Settings.get_default().gtk_enable_animations)
-        tweeningParameters['time'] = 0.000001;
+    //if (!Gtk.Settings.get_default().gtk_enable_animations)
+    //    tweeningParameters['time'] = 0.000001;
 
     _addHandler(target, tweeningParameters, 'onComplete', _tweenCompleted);
 }

--- a/js/ui/windowManager.js
+++ b/js/ui/windowManager.js
@@ -607,7 +607,7 @@ const WindowManager = new Lang.Class({
                                         function () { Main.layoutManager.emit('background-clicked'); });
         }));
 
-        this._codingManager = new CodingManager.CodingManager();
+        this._codingManager = new CodingManager.CodeViewManager({});
 
         this._switchData = null;
         this._shellwm.connect('kill-switch-workspace', Lang.bind(this, this._switchWorkspaceDone));


### PR DESCRIPTION
For instance, we might be interested in whether the underlying flatpak sources have been downloaded, or if the window has been flipped. One such consumer is coding-game-service, which needs to know about these events in order to move forward with some of the interactions.

https://phabricator.endlessm.com/T13630