### PR TITLE
updaterManager: Ignore errors from running on live booted systems

### DIFF
--- a/js/ui/components/updaterManager.js
+++ b/js/ui/components/updaterManager.js
@@ -269,8 +269,9 @@ const UpdaterManager = new Lang.Class({
         }
 
         // We don’t want to notify of errors arising from being a dev-converted
-        // system.
-        if (this._proxy.ErrorName == 'com.endlessm.Updater.Error.NotOstreeSystem') {
+        // system or live system.
+        if (this._proxy.ErrorName == 'com.endlessm.Updater.Error.NotOstreeSystem' ||
+            this._proxy.ErrorName == 'com.endlessm.Updater.Error.LiveBoot') {
             return;
         }
 


### PR DESCRIPTION
eos-updater will not update a live-booted system, so do not show errors
from it saying the system is live booted.

Signed-off-by: Philip Withnall <withnall@endlessm.com>

https://phabricator.endlessm.com/T15977