### PR TITLE
messageTray: Hide overview on notification activation

### DIFF
--- a/js/ui/notificationDaemon.js
+++ b/js/ui/notificationDaemon.js
@@ -852,11 +852,13 @@ const GtkNotificationDaemonAppSource = new Lang.Class({
     activateAction: function(actionId, target) {
         let app = this._createApp();
         app.ActivateActionRemote(actionId, target ? [target] : [], getPlatformData());
+        Main.overview.hide();
     },
 
     open: function() {
         let app = this._createApp();
         app.ActivateRemote(getPlatformData());
+        Main.overview.hide();
     },
 
     addNotification: function(notificationId, notificationParams, showBanner) {


### PR DESCRIPTION
Pressing the notification when the overview was in front of all the
non-minimized windows of other applications didn't result in the
application window being shown. Hide the overview explicitly then.

https://phabricator.endlessm.com/T16208

This looks a bit like a blunt way to hide the overview, but I noticed that there was a prior art in fdo notifications handling, so I followed suit.