### PR TITLE
CodeView: use the flatpakID for upstream GNOME Weather

### DIFF
--- a/js/ui/codingManager.js
+++ b/js/ui/codingManager.js
@@ -27,7 +27,7 @@ const STATE_BUILDER = 1;
 
 const _CODING_APPS = [
     'com.endlessm.Helloworld',
-    'org.gnome.Weather.Application'
+    'org.gnome.Weather'
 ];
 
 function _isCodingApp(flatpakID) {


### PR DESCRIPTION
We want to pull in the upstream version instead of
our custom endless one. Part of T16393

This basically reverts: a6de674cfc6547ee024b6afdcde47593285449cc