### PR TITLE
Adapt eos-shell 3.8 to build and run on top of mutter 3.22 

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -55,7 +55,7 @@ if $PKG_CONFIG --exists gstreamer-1.0 '>=' $GSTREAMER_MIN_VERSION ; then
    AC_MSG_RESULT(yes)
    build_recorder=true
    recorder_modules="gstreamer-1.0 gstreamer-base-1.0 x11 gtk+-3.0"
-   PKG_CHECK_MODULES(TEST_SHELL_RECORDER, $recorder_modules clutter-1.0 xfixes)
+   PKG_CHECK_MODULES(TEST_SHELL_RECORDER, $recorder_modules mutter-clutter-1.0 xfixes)
 else
    AC_MSG_RESULT(no)
 fi
@@ -77,10 +77,10 @@ AS_IF([test x$enable_systemd != xno], [
 
 AC_MSG_RESULT($enable_systemd)
 
-CLUTTER_MIN_VERSION=1.13.4
+CLUTTER_MIN_VERSION=1.21.5
 GOBJECT_INTROSPECTION_MIN_VERSION=0.10.1
 GJS_MIN_VERSION=1.36.1
-MUTTER_MIN_VERSION=3.8.0
+MUTTER_MIN_VERSION=3.22.1
 GTK_MIN_VERSION=3.7.9
 GIO_MIN_VERSION=2.35.0
 LIBECAL_MIN_VERSION=3.5.3
@@ -97,12 +97,11 @@ PKG_CHECK_MODULES(EOS_SHELL, gio-unix-2.0 >= $GIO_MIN_VERSION
 			       libxml-2.0
                                gtk+-3.0 >= $GTK_MIN_VERSION
                                atk-bridge-2.0
-                               libmutter >= $MUTTER_MIN_VERSION
                                gjs-1.0 >= $GJS_MIN_VERSION
                                $recorder_modules
                                gdk-x11-3.0 libsoup-2.4
-			       clutter-x11-1.0 >= $CLUTTER_MIN_VERSION
-			       clutter-glx-1.0 >= $CLUTTER_MIN_VERSION
+                               mutter-clutter-1.0 >= $CLUTTER_MIN_VERSION
+                               mutter-cogl-pango-1.0
                                libstartup-notification-1.0 >= $STARTUP_NOTIFICATION_MIN_VERSION
                                gobject-introspection-1.0 >= $GOBJECT_INTROSPECTION_MIN_VERSION
 			       libcanberra libcanberra-gtk3
@@ -113,8 +112,10 @@ PKG_CHECK_MODULES(EOS_SHELL, gio-unix-2.0 >= $GIO_MIN_VERSION
                                eosmetrics-0)
 
 PKG_CHECK_MODULES(EOS_SHELL_JS, gio-2.0 gjs-1.0 >= $GJS_MIN_VERSION)
-PKG_CHECK_MODULES(ST, clutter-1.0 gtk+-3.0 libcroco-0.6 >= 0.6.8 x11)
-PKG_CHECK_MODULES(EOS_SHELL_FX, clutter-1.0 >= 1.16 glib-2.0 >= 2.38 libwindowfx_wobbly)
+PKG_CHECK_MODULES(MUTTER, libmutter >= $MUTTER_MIN_VERSION)
+
+PKG_CHECK_MODULES(ST, mutter-clutter-1.0 gtk+-3.0 libcroco-0.6 >= 0.6.8 x11)
+PKG_CHECK_MODULES(EOS_SHELL_FX, mutter-clutter-1.0 >= 1.16 glib-2.0 >= 2.38 libwindowfx_wobbly)
 PKG_CHECK_MODULES(SHELL_PERF_HELPER, gtk+-3.0 gio-2.0)
 PKG_CHECK_MODULES(SHELL_HOTPLUG_SNIFFER, gio-2.0 gdk-pixbuf-2.0)
 PKG_CHECK_MODULES(TRAY, gtk+-3.0)

--- a/js/ui/windowManager.js
+++ b/js/ui/windowManager.js
@@ -37,7 +37,7 @@ const DIM_TIME = 0.500;
 const UNDIM_TIME = 0.250;
 const SKYPE_WINDOW_CLOSE_TIMEOUT_MS = 1000;
 
-const DISPLAY_REVERT_TIMEOUT = 30; // in seconds - keep in sync with mutter
+const DISPLAY_REVERT_TIMEOUT = 20; // in seconds - keep in sync with mutter
 const ONE_SECOND = 1000; // in ms
 
 const DisplayChangeDialog = new Lang.Class({

--- a/js/ui/windowManager.js
+++ b/js/ui/windowManager.js
@@ -37,7 +37,6 @@ const DIM_TIME = 0.500;
 const UNDIM_TIME = 0.250;
 const SKYPE_WINDOW_CLOSE_TIMEOUT_MS = 1000;
 
-const DISPLAY_REVERT_TIMEOUT = 20; // in seconds - keep in sync with mutter
 const ONE_SECOND = 1000; // in ms
 
 const DisplayChangeDialog = new Lang.Class({
@@ -73,7 +72,7 @@ const DisplayChangeDialog = new Lang.Class({
                        { y_fill:  false,
                          y_align: St.Align.START });
 
-        this._countDown = DISPLAY_REVERT_TIMEOUT;
+        this._countDown = Meta.prefs_get_display_configuration_timeout();
         let message = this._formatCountDown();
         this._descriptionLabel = new St.Label({ style_class: 'prompt-dialog-description',
                                                 text: this._formatCountDown() });

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -13,7 +13,7 @@ SUBDIRS = gvc
 
 -include $(INTROSPECTION_MAKEFILE)
 INTROSPECTION_GIRS =
-INTROSPECTION_SCANNER_ARGS = --warn-all --warn-error --add-include-path=$(srcdir)
+INTROSPECTION_SCANNER_ARGS = --warn-all --warn-error --add-include-path=$(srcdir) --add-include-path=$(MUTTER_GIR_DIR) -L$(MUTTER_TYPELIB_DIR)
 INTROSPECTION_COMPILER_ARGS = --includedir=$(srcdir) --includedir=$(MUTTER_TYPELIB_DIR)
 
 typelibdir = $(pkglibdir)
@@ -96,6 +96,7 @@ include Makefile-hotplug-sniffer.am
 
 eos_shell_cflags =				\
 	$(EOS_SHELL_CFLAGS)			\
+	$(MUTTER_CFLAGS)			\
 	@EOS_C_COVERAGE_CFLAGS@			\
 	-I$(srcdir)/tray			\
 	-DVERSION=\"$(VERSION)\"		\
@@ -217,7 +218,7 @@ eos_shell_real_SOURCES =		\
 	main.c
 eos_shell_real_CPPFLAGS = $(eos_shell_cflags)
 eos_shell_real_LDADD = libeos-shell.la libeos-shell-fx.la $(libeos_shell_la_LIBADD)
-eos_shell_real_LDFLAGS = @EOS_C_COVERAGE_LDFLAGS@
+eos_shell_real_LDFLAGS = @EOS_C_COVERAGE_LDFLAGS@ -rpath $(MUTTER_TYPELIB_DIR)
 
 eos_shell_extension_prefs_SOURCES = 	\
 	gnome-shell-extension-prefs.c 	\
@@ -228,7 +229,7 @@ nodist_eos_shell_extension_prefs_SOURCES = \
 	$(NULL)
 eos_shell_extension_prefs_CPPFLAGS = $(eos_shell_cflags)
 eos_shell_extension_prefs_LDADD = $(EOS_SHELL_LIBS) -lm
-eos_shell_extension_prefs_LDFLAGS = @EOS_C_COVERAGE_LDFLAGS@
+eos_shell_extension_prefs_LDFLAGS = @EOS_C_COVERAGE_LDFLAGS@ -rpath $(MUTTER_TYPELIB_DIR)
 
 ########################################
 
@@ -291,9 +292,9 @@ eos_shell_perf_helper_LDFLAGS = @EOS_C_COVERAGE_LDFLAGS@
 
 noinst_PROGRAMS += run-js-test
 
-run_js_test_CPPFLAGS = $(eos_shell_cflags)
-run_js_test_LDADD = libeos-shell.la $(libeos_shell_la_LIBADD)
-run_js_test_LDFLAGS = -export-dynamic
+run_js_test_CPPFLAGS = $(MUTTER_CFLAGS) $(eos_shell_cflags)
+run_js_test_LDADD = libeos-shell.la $(libeos_shell_la_LIBADD) $(MUTTER_LIBS)
+run_js_test_LDFLAGS = -export-dynamic -rpath $(MUTTER_TYPELIB_DIR)
 
 run_js_test_SOURCES =			\
 	run-js-test.c
@@ -328,13 +329,14 @@ libeos_shell_la_LIBADD =		\
 	-lm				\
 	@EOS_C_COVERAGE_LDFLAGS@	\
 	$(EOS_SHELL_LIBS)		\
+	$(MUTTER_LIBS)			\
 	$(BLUETOOTH_LIBS)		\
 	libst-1.0.la       		\
 	libtray.la			\
 	gvc/libgvc.la			\
 	$(NULL)
 
-libeos_shell_la_CPPFLAGS = $(eos_shell_cflags)
+libeos_shell_la_CPPFLAGS = $(eos_shell_cflags) $(MUTTER_CFLAGS)
 
 ShellMenu-0.1.gir: libeos-shell.la
 ShellMenu_0_1_gir_INCLUDES = Gio-2.0

--- a/src/shell-global.c
+++ b/src/shell-global.c
@@ -18,7 +18,6 @@
 #include <X11/extensions/Xfixes.h>
 #include <canberra.h>
 #include <canberra-gtk.h>
-#include <clutter/glx/clutter-glx.h>
 #include <clutter/x11/clutter-x11.h>
 #include <gdk/gdkx.h>
 #include <gio/gio.h>

--- a/src/shell-slicer.c
+++ b/src/shell-slicer.c
@@ -117,14 +117,14 @@ shell_slicer_paint_child (ShellSlicer *self)
 
   cogl_push_matrix ();
 
-  cogl_clip_push_rectangle (0, 0, width, height);
+  cogl_framebuffer_push_rectangle_clip (cogl_get_draw_framebuffer (), 0, 0, width, height);
   cogl_translate ((int)(0.5 + x_align_factor * (width - child_width)),
                   (int)(0.5 + y_align_factor * (height - child_height)),
                   0);
 
   clutter_actor_paint (child);
 
-  cogl_clip_pop ();
+  cogl_framebuffer_pop_clip (cogl_get_draw_framebuffer ());
 
   cogl_pop_matrix ();
 }

--- a/src/st/st-box-layout.c
+++ b/src/st/st-box-layout.c
@@ -921,10 +921,11 @@ st_box_layout_paint (ClutterActor *actor)
    * the borders and background stay in place; after drawing the borders and
    * background, we clip to the content area */
   if (priv->hadjustment || priv->vadjustment)
-    cogl_clip_push_rectangle ((int)content_box.x1,
-                              (int)content_box.y1,
-                              (int)content_box.x2,
-                              (int)content_box.y2);
+    cogl_framebuffer_push_rectangle_clip (cogl_get_draw_framebuffer (),
+                                          (int)content_box.x1,
+                                          (int)content_box.y1,
+                                          (int)content_box.x2,
+                                          (int)content_box.y2);
 
   for (child = clutter_actor_get_first_child (actor);
        child != NULL;
@@ -932,7 +933,7 @@ st_box_layout_paint (ClutterActor *actor)
     clutter_actor_paint (child);
 
   if (priv->hadjustment || priv->vadjustment)
-    cogl_clip_pop ();
+    cogl_framebuffer_pop_clip (cogl_get_draw_framebuffer ());
 }
 
 static void
@@ -973,10 +974,11 @@ st_box_layout_pick (ClutterActor       *actor,
   content_box.y2 += y;
 
   if (priv->hadjustment || priv->vadjustment)
-    cogl_clip_push_rectangle ((int)content_box.x1,
-                              (int)content_box.y1,
-                              (int)content_box.x2,
-                              (int)content_box.y2);
+    cogl_framebuffer_push_rectangle_clip (cogl_get_draw_framebuffer (),
+                                          (int)content_box.x1,
+                                          (int)content_box.y1,
+                                          (int)content_box.x2,
+                                          (int)content_box.y2);
 
   for (child = clutter_actor_get_first_child (actor);
        child != NULL;
@@ -984,7 +986,7 @@ st_box_layout_pick (ClutterActor       *actor,
     clutter_actor_paint (child);
 
   if (priv->hadjustment || priv->vadjustment)
-    cogl_clip_pop ();
+    cogl_framebuffer_pop_clip (cogl_get_draw_framebuffer ());
 }
 
 static gboolean

--- a/src/st/st-theme-node-drawing.c
+++ b/src/st/st-theme-node-drawing.c
@@ -2498,7 +2498,7 @@ st_theme_node_paint (StThemeNode           *node,
       get_background_position (node, &allocation, &background_box, &texture_coords);
 
       if (has_visible_outline || node->background_repeat)
-        cogl_clip_push_rectangle (allocation.x1, allocation.y1, allocation.x2, allocation.y2);
+        cogl_framebuffer_push_rectangle_clip (cogl_get_draw_framebuffer (), allocation.x1, allocation.y1, allocation.x2, allocation.y2);
 
       /* CSS based drop shadows
        *
@@ -2525,7 +2525,7 @@ st_theme_node_paint (StThemeNode           *node,
                                    paint_opacity);
 
       if (has_visible_outline || node->background_repeat)
-        cogl_clip_pop ();
+        cogl_framebuffer_pop_clip (cogl_get_draw_framebuffer ());
     }
 }
 


### PR DESCRIPTION
A few small changes are required now that mutter bundles its own private and newer versions of cogl and clutter, so that eos-shell can find and use the right libraries and APIs. 

https://phabricator.endlessm.com/T16276