### PR TITLE
Don't prematurely add an icon coming from a folder to the main view

### DIFF
--- a/js/ui/appDisplay.js
+++ b/js/ui/appDisplay.js
@@ -972,24 +972,14 @@ const AllView = new Lang.Class({
         this._dragView.repositionedIconData = [ this._originalIdx, position ];
         this._repositionedView = this._dragView;
 
-        // If we dropped the icon outside of the folder, close the popup and
-        // add the icon to the main view
+        // If we dropped the icon outside of the folder, close the popup
         if (droppedOutsideOfFolder) {
             source.blockHandler = true;
             this._eventBlocker.reactive = false;
             this._currentPopup.popdown();
-
-            // Append the inserted icon to the end of the grid
-            let appSystem = Shell.AppSystem.get_default();
-            let item = appSystem.lookup_app(source.getId());
-            let icon = this._dragView._createItemIcon(item);
-            this._dragView.addIcon(icon);
-
-            // Set it as the repositioned icon
-            let desktopIcons = this._dragView.getAllIcons();
-            this._dragView.repositionedIconData = [ desktopIcons.length - 1, position ];
         }
 
+        // Reposition the icon in the main view
         IconGridLayout.layout.repositionIcon(source.getId(), insertId, folderId);
         return true;
     },

--- a/js/ui/iconGrid.js
+++ b/js/ui/iconGrid.js
@@ -707,10 +707,6 @@ const IconGrid = new Lang.Class({
     },
 
     animateShuffling: function(changedItems, removedItems, originalItemData, callback) {
-        // We need to repaint the grid since the last icon added might not be
-        // drawn yet
-        this.actor.paint();
-
         let children = this.actor.get_children();
         let node = this.actor.get_theme_node();
         let contentBox = node.get_content_box(this.actor.allocation);


### PR DESCRIPTION
This is the reason why we have a hack in animateShuffling() to force
a repaint of the main view right before animating the icon, which we
can't use anymore as it relied in some undefined behaviour in clutter
that is no longer working as "expected", and now crashes the shell.

Besides, there is no need to artificially add the icon to the main view
when dragging it from inside a folder into the main grid layout, as it
will be inserted anyway in IconGridLayout.layout.repositionIcon.

Also, artificially adding that icon to the list really confused the logic
that finds out which icons need to be moved in the icon grid, which unmasked
a bug during the animation only visible after removing the call to paint(),
so this is seems to be also cleaner now.

https://phabricator.endlessm.com/T16707